### PR TITLE
 ENG-201 - fix casing in safe's "owners" array

### DIFF
--- a/src/store/daoInfo/useDaoInfoStore.ts
+++ b/src/store/daoInfo/useDaoInfoStore.ts
@@ -28,8 +28,8 @@ export const useDaoInfoStore = create<DaoInfoStore>()(set => ({
     const { address, owners, nonce, nextNonce, threshold, modules, guard } = safe;
     set({
       safe: {
-        owners: owners.map(getAddress),
-        modulesAddresses: modules.map(getAddress),
+        owners: owners.map(owner => getAddress(owner)),
+        modulesAddresses: modules.map(module => getAddress(module)),
         guard: getAddress(guard),
         address: getAddress(address),
         nextNonce,


### PR DESCRIPTION
`getAddress` takes an optional second parameter, which messes with the checksummed encoding, that was accidentally be passed the index of the map. oops.

Fixes https://linear.app/decent-labs/issue/ENG-201/multisig-unable-to-vote-as-additional-non-proposer-signer