### PR TITLE
Refactor Safe modules retrieval to use paginated fetching

### DIFF
--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -193,21 +193,21 @@ class EnhancedSafeApiKit {
       // Fetch modules
       let startAddress: Address = SENTINEL_ADDRESS;
       let nextAddress: Address = zeroAddress; // placeholder
-      const modules: Address[] = [];
+      const allModules: Address[] = [];
 
       while (nextAddress !== SENTINEL_ADDRESS) {
         const lastModuleResponse = await this.publicClient.readContract({
           address: checksummedSafeAddress,
           abi: GnosisSafeL2Abi,
           functionName: 'getModulesPaginated',
-          args: [startAddress, 1n], // get one module per page
+          args: [startAddress, 10n], // get 10 modules per page
         });
-        const strategies = lastModuleResponse[0]; // "one page" of modules
+        const pageOfModules = lastModuleResponse[0]; // one page of modules
         const next = lastModuleResponse[1]; // cursor for next page
 
         // a Safe might not have any modules installed
-        if (strategies.length > 0) {
-          modules.push(strategies[0]); // only one module per page
+        if (pageOfModules.length > 0) {
+          allModules.push(...pageOfModules);
         }
 
         nextAddress = next;
@@ -219,7 +219,7 @@ class EnhancedSafeApiKit {
         nonce: Number(nonce ? nonce : 0),
         threshold: Number(threshold ? threshold : 0),
         owners: owners as string[],
-        modules: modules,
+        modules: allModules,
         fallbackHandler: zeroAddress, // not used
         guard: guardStorageValue ? getAddress(`0x${guardStorageValue.slice(-40)}`) : zeroAddress,
         version: version,


### PR DESCRIPTION
Closes https://linear.app/decent-labs/issue/ENG-343/app-not-displaying-correct-list-of-modules-attached-to-a-safe

# PR: Improve Safe Module Retrieval in getSafeInfo Method

## Description

This PR improves the implementation of module retrieval in the `getSafeInfo` method to properly handle all installed modules in a Safe account. The changes ensure we correctly traverse the linked list structure used by Safe contracts to store modules, guaranteeing that we retrieve all installed modules regardless of how many exist.

## Safe Module System Overview

In Safe contracts, modules are stored in a linked list structure:

- Modules are stored in a mapping where each entry points to the next module
- A special sentinel address (`0x1`) marks both the start and end of the list
- The `getModulesPaginated` function returns a subset of modules and the next address to continue pagination

From [ModuleManager.sol](https://github.com/safe-global/safe-smart-account/blob/v1.3.0/contracts/base/ModuleManager.sol):

```solidity
address internal constant SENTINEL_MODULES = address(0x1);
mapping(address => address) internal modules;
```

## Changes Made

### Previous Implementation (pseudocode):
```typescript
const moduleResponse = await this.publicClient.readContract({
  address: checksummedSafeAddress,
  abi: GnosisSafeL2Abi,
  functionName: 'getModulesPaginated',
  args: [SENTINEL_ADDRESS, 10n], // get up to 10 modules
});

const [modules, next] = moduleResponse;

return {
  ...
  modules: [...modules, next],
  ...
};
```

The previous implementation only made a single call with a page size of 10, which could miss modules if more than 10 were installed. It also included the `next` cursor into the result set which was given to the caller of `useSafeAPI()`.

### New Implementation:
```typescript
// Fetch modules
let startAddress: Address = SENTINEL_ADDRESS;
let nextAddress: Address = zeroAddress; // placeholder
const modules: Address[] = [];

while (nextAddress !== SENTINEL_ADDRESS) {
  const lastModuleResponse = await this.publicClient.readContract({
    address: checksummedSafeAddress,
    abi: GnosisSafeL2Abi,
    functionName: 'getModulesPaginated',
    args: [startAddress, 1n], // get one module per page
  });
  const strategies = lastModuleResponse[0]; // "one page" of modules
  const next = lastModuleResponse[1]; // cursor for next page

  // a Safe might not have any modules installed
  if (strategies.length > 0) {
    modules.push(strategies[0]); // only one module per page
  }

  nextAddress = next;
  startAddress = nextAddress;
}
```

## Why This is Better

1. **Complete module retrieval**: The new implementation guarantees all modules will be retrieved by iterating through the entire linked list until reaching the sentinel value again.

2. **Proper handling of the linked list**: Rather than assuming a fixed number of modules, we traverse the list as intended by the Safe contracts' design.

3. **Edge case handling**: Properly handles cases where no modules are installed or where there are more than 10 modules.

4. **Reliability**: Ensures our application always has the complete set of modules, which is crucial for features that depend on module awareness.

This change addresses potential inconsistencies that could occur if a Safe had more than 10 installed modules, providing a more robust implementation that aligns with the Safe contract's module storage system.