### PR TITLE
Feature/eng 236 Create Proposal - Adding and removing actions doesn't change transactions / executable code

### DIFF
--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -79,8 +79,8 @@ export function SafeProposalWithActionsCreatePage() {
   const { safe } = useDaoInfoStore();
 
   const { prepareProposal } = usePrepareProposal();
-  const { getTransactions } = useProposalActionsStore();
-  const transactions = useMemo(() => getTransactions(), [getTransactions]);
+  const { getTransactions, actions } = useProposalActionsStore();
+  const transactions = useMemo(() => getTransactions(), [getTransactions, actions]);
   const { addressPrefix } = useNetworkConfigStore();
 
   const HEADER_HEIGHT = useHeaderHeight();


### PR DESCRIPTION
### Issue

- [ ] transactions got memo-ed but without `actions` as dependency, so it's not updated with actions changing
- [ ] proposal metadata turns into empty/default because `transactions` is a field passed as render prop of `ProposalBuilder` which has all the form context.