### PR TITLE
`[ENG-250]` Allow Error text to show as design in organization page

### DIFF
--- a/src/components/DaoHierarchy/DaoHierarchyNode.tsx
+++ b/src/components/DaoHierarchy/DaoHierarchyNode.tsx
@@ -205,20 +205,6 @@ export function DaoHierarchyNode({
     }
   }, [chain.id, loadDao, safeAddress]);
 
-  if (!hierarchyNode) {
-    // node hasn't loaded yet
-    return (
-      <Flex
-        w="full"
-        minH="full"
-      >
-        <Center w="100%">
-          <BarLoader />
-        </Center>
-      </Flex>
-    );
-  }
-
   if (hasErrorLoading) {
     return (
       <Flex
@@ -237,6 +223,20 @@ export function DaoHierarchyNode({
           >
             {t('errorMySafesNotLoaded')}
           </Text>
+        </Center>
+      </Flex>
+    );
+  }
+
+  if (!hierarchyNode) {
+    // node hasn't loaded yet
+    return (
+      <Flex
+        w="full"
+        minH="full"
+      >
+        <Center w="100%">
+          <BarLoader />
         </Center>
       </Flex>
     );


### PR DESCRIPTION
Just unlocked the UI that was already there to handle when data isn't returned. I guess its hard without some extra logic to decide tell if this is a 'import' with no graph data and a error happening with the graph request. 

## Screenshot
![localhost_3000_hierarchy_dao=base_0x4F6F99828B204bBe6F7a2D014166537e37aCb82C(Desktop)](https://github.com/user-attachments/assets/8ac6b6e4-e97b-41b5-9808-a7fc7b4f96ec)

