### PR TITLE
`[ENG-238]` Update proposal submission voting strategy error handling

### DIFF
--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -386,13 +386,17 @@ export default function useSubmitProposal() {
                 if (!votingStrategy) {
                   return { isProposer: false, votingStrategy };
                 }
-                const votingContract = getContract({
-                  abi: abis.LinearERC20Voting,
-                  client: publicClient,
-                  address: votingStrategy,
-                });
-                const isProposer = await votingContract.read.isProposer([userAddress]);
-                return { isProposer, votingStrategy };
+                try {
+                  const votingContract = getContract({
+                    abi: abis.LinearERC20Voting,
+                    client: publicClient,
+                    address: votingStrategy,
+                  });
+                  const isProposer = await votingContract.read.isProposer([userAddress]);
+                  return { isProposer, votingStrategy };
+                } catch (e) {
+                  return { isProposer: false, votingStrategy };
+                }
               }),
             )
           ).find(votingStrategy => votingStrategy.isProposer);


### PR DESCRIPTION
Closes [ENG-238](https://linear.app/decent-labs/issue/ENG-238/sub-dao-cannot-create-proposals)

There was a check for `isProposer` that was being called on all 'voting strategies'. This includes `ERC20FreezeVoting` which doesn't have this method. wrapped this section in a try catch. 