### PR TITLE
`ENG-361` take dApp transaction, decode and then create a proposal

### DIFF
--- a/src/components/ProposalBuilder/ProposalActionCard.tsx
+++ b/src/components/ProposalBuilder/ProposalActionCard.tsx
@@ -7,6 +7,7 @@ import { useFractal } from '../../providers/App/AppProvider';
 import { useProposalActionsStore } from '../../store/actions/useProposalActionsStore';
 import { CreateProposalAction, ProposalActionType } from '../../types/proposalBuilder';
 import { Card } from '../ui/cards/Card';
+import { DappInteractionActionCard } from '../ui/cards/DappInteractionActionCard';
 import { SendAssetsActionCard } from '../ui/cards/SendAssetsActionCard';
 
 function SendAssetsAction({
@@ -154,6 +155,13 @@ export function ProposalActionCard({
   } else if (action.actionType === ProposalActionType.AIRDROP) {
     return (
       <AirdropAction
+        action={action}
+        onRemove={() => removeAction(index)}
+      />
+    );
+  } else if (action.actionType === ProposalActionType.DAPP_INTEGRATION) {
+    return (
+      <DappInteractionActionCard
         action={action}
         onRemove={() => removeAction(index)}
       />

--- a/src/components/ProposalBuilder/ProposalTransaction.tsx
+++ b/src/components/ProposalBuilder/ProposalTransaction.tsx
@@ -14,9 +14,10 @@ import {
 import { CaretDown, CaretRight, MinusCircle, Plus } from '@phosphor-icons/react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ABIElement } from '../../hooks/utils/useABI';
 import { CreateProposalTransaction } from '../../types/proposalBuilder';
 import { scrollToBottom } from '../../utils/ui';
-import ABISelector, { ABIElement } from '../ui/forms/ABISelector';
+import ABISelector from '../ui/forms/ABISelector';
 import ExampleLabel from '../ui/forms/ExampleLabel';
 import { BigIntComponent, InputComponent } from '../ui/forms/InputComponent';
 import CeleryButtonWithIcon from '../ui/utils/CeleryButtonWithIcon';

--- a/src/components/SafeInjectIframe/context/SafeInjectContext.tsx
+++ b/src/components/SafeInjectIframe/context/SafeInjectContext.tsx
@@ -23,8 +23,8 @@ type SafeInjectContextType = {
   /**
    * Transactions intercepted from iframe
    */
-  latestTransactions: TransactionWithId[] | undefined;
-  setLatestTransactions: React.Dispatch<React.SetStateAction<TransactionWithId[] | undefined>>;
+  latestTransactions: TransactionWithId[];
+  setLatestTransactions: (transactions: TransactionWithId[]) => void;
   setAddress: React.Dispatch<React.SetStateAction<string | undefined>>;
   setAppUrl: React.Dispatch<React.SetStateAction<string | undefined>>;
   /**
@@ -39,7 +39,7 @@ export const SafeInjectContext = createContext<SafeInjectContextType>({
   connecting: false,
   connectedAppUrl: '',
   iframeRef: null,
-  latestTransactions: undefined,
+  latestTransactions: [],
   setLatestTransactions: () => {},
   setAddress: () => {},
   setAppUrl: () => {},

--- a/src/components/SafeInjectIframe/context/SafeInjectProvider.tsx
+++ b/src/components/SafeInjectIframe/context/SafeInjectProvider.tsx
@@ -179,7 +179,15 @@ export function SafeInjectProvider({
       //   and "confirmed" so it can continue
       return true;
     });
-  }, [communicator, address, chainId, publicClient, appUrl, receivedTransactions]);
+  }, [
+    communicator,
+    address,
+    chainId,
+    publicClient,
+    appUrl,
+    receivedTransactions,
+    receivedConnection,
+  ]);
 
   return (
     <SafeInjectContext.Provider

--- a/src/components/ui/cards/DappInteractionActionCard.tsx
+++ b/src/components/ui/cards/DappInteractionActionCard.tsx
@@ -1,0 +1,38 @@
+import { Button, Card, Flex, Icon } from '@chakra-ui/react';
+import { ArrowsDownUp, Trash } from '@phosphor-icons/react';
+import { CreateProposalAction } from '../../../types';
+
+export function DappInteractionActionCard({
+  action,
+  onRemove,
+}: {
+  action: CreateProposalAction;
+  onRemove: () => void;
+}) {
+  return (
+    <Card my="0.5rem">
+      <Flex justifyContent="space-between">
+        <Flex
+          alignItems="center"
+          gap="0.5rem"
+        >
+          <Icon
+            as={ArrowsDownUp}
+            w="1.5rem"
+            h="1.5rem"
+            color="lilac-0"
+          />
+          {action.content}
+        </Flex>
+        <Button
+          color="red-0"
+          variant="tertiary"
+          size="sm"
+          onClick={onRemove}
+        >
+          <Icon as={Trash} />
+        </Button>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/ui/forms/ABISelector.tsx
+++ b/src/components/ui/forms/ABISelector.tsx
@@ -1,21 +1,8 @@
 import { Select, Text } from '@chakra-ui/react';
-import axios from 'axios';
-import detectProxyTarget from 'evm-proxy-detection';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isAddress } from 'viem';
-import { logError } from '../../../helpers/errorLogging';
-import { useNetworkEnsAddress } from '../../../hooks/useNetworkEnsAddress';
-import useNetworkPublicClient from '../../../hooks/useNetworkPublicClient';
-import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
+import { ABIElement, useABI } from '../../../hooks/utils/useABI';
 import { LabelComponent } from './InputComponent';
-
-export type ABIElement = {
-  type: 'function' | 'constructor' | 'fallback' | 'event';
-  name: string;
-  stateMutability: 'view' | 'nonpayable' | 'pure';
-  inputs: { type: string; name: string; internalType: string }[];
-};
 
 interface IABISelector {
   /*
@@ -26,45 +13,8 @@ interface IABISelector {
 }
 
 export default function ABISelector({ target, onChange }: IABISelector) {
-  const [abi, setABI] = useState<ABIElement[]>([]);
-  const { etherscanAPIUrl, chain } = useNetworkConfigStore();
+  const { abi } = useABI(target);
   const { t } = useTranslation('common');
-  const { data: ensAddress } = useNetworkEnsAddress({
-    name: target?.toLowerCase(),
-    chainId: chain.id,
-  });
-  const client = useNetworkPublicClient();
-
-  useEffect(() => {
-    const loadABI = async () => {
-      if (target && ((ensAddress && isAddress(ensAddress)) || isAddress(target))) {
-        try {
-          const requestFunc = ({ method, params }: { method: any; params: any }) =>
-            client.request({ method, params });
-
-          const implementationAddress = await detectProxyTarget(ensAddress || target, requestFunc);
-
-          const response = await axios.get(
-            `${etherscanAPIUrl}&module=contract&action=getabi&address=${implementationAddress || ensAddress || target}`,
-          );
-          const responseData = response.data;
-
-          if (responseData.status === '1') {
-            const fetchedABI = JSON.parse(responseData.result);
-            setABI(fetchedABI);
-          } else {
-            setABI([]);
-          }
-        } catch (e) {
-          setABI([]);
-          logError(e, 'Error fetching ABI for smart contract');
-        }
-      } else {
-        setABI([]);
-      }
-    };
-    loadABI();
-  }, [target, ensAddress, etherscanAPIUrl, client]);
 
   /*
    * This makes component quite scoped to proposal / proposal template creation

--- a/src/components/ui/modals/ConfirmTransactionModal.tsx
+++ b/src/components/ui/modals/ConfirmTransactionModal.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../types';
 import ProposalTransactionsForm from '../../ProposalBuilder/ProposalTransactionsForm';
 import Divider from '../utils/Divider';
-import da from 'date-fns/esm/locale/da/index';
 
 /**
  * Use ProposalTransactionsForm to render transactions, add them to actionsStore

--- a/src/components/ui/modals/ConfirmTransactionModal.tsx
+++ b/src/components/ui/modals/ConfirmTransactionModal.tsx
@@ -1,0 +1,94 @@
+import { Box, Button, Text } from '@chakra-ui/react';
+import { Formik, FormikProps } from 'formik';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { DAO_ROUTES } from '../../../constants/routes';
+import useCreateProposalSchema from '../../../hooks/schemas/proposalBuilder/useCreateProposalSchema';
+import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
+import { useProposalActionsStore } from '../../../store/actions/useProposalActionsStore';
+import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
+import {
+  CreateProposalActionData,
+  CreateProposalForm,
+  CreateProposalTransaction,
+  ProposalActionType,
+} from '../../../types';
+import ProposalTransactionsForm from '../../ProposalBuilder/ProposalTransactionsForm';
+import { DEFAULT_PROPOSAL } from '../../ProposalBuilder/constants';
+import Divider from '../utils/Divider';
+
+/**
+ * Use ProposalTransactionsForm to render transactions, add them to actionsStore
+ *   if confirmed by user and then navigate to proposalWithActionNew page.
+ */
+export function ConfirmTransactionModal({
+  transactionArray,
+  close,
+}: {
+  transactionArray: CreateProposalTransaction[];
+  close: () => void;
+}) {
+  const { t } = useTranslation('modals');
+  const { safe } = useDaoInfoStore();
+  const { addressPrefix } = useNetworkConfigStore();
+  const { addAction } = useProposalActionsStore();
+  const navigate = useNavigate();
+
+  const { createProposalValidation } = useCreateProposalSchema();
+
+  return (
+    <Formik<CreateProposalForm>
+      validationSchema={createProposalValidation}
+      initialValues={{ ...DEFAULT_PROPOSAL, transactions: transactionArray }}
+      enableReinitialize
+      onSubmit={async values => {
+        if (!safe?.address) {
+          return;
+        }
+
+        const action: CreateProposalActionData = {
+          actionType: ProposalActionType.DAPP_INTERACTION,
+          transactions: values.transactions,
+        };
+        addAction({ ...action, content: <></> });
+        navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safe.address));
+      }}
+    >
+      {(formikProps: FormikProps<CreateProposalForm>) => {
+        const createProposalButtonDisabled = Object.keys(formikProps.errors).length > 0;
+
+        return (
+          <form onSubmit={formikProps.handleSubmit}>
+            <Box>
+              <Box>
+                <ProposalTransactionsForm
+                  pendingTransaction={false}
+                  isProposalMode={true}
+                  {...formikProps}
+                />
+                <Divider marginBottom="1rem" />
+                <Text marginBottom="1rem">{t('confirmAction')}</Text>
+                <Button
+                  width="100%"
+                  onClick={close}
+                  type="submit"
+                  disabled={createProposalButtonDisabled}
+                >
+                  {t('modalContinue')}
+                </Button>
+                <Button
+                  marginTop="0.5rem"
+                  width="100%"
+                  variant="tertiary"
+                  onClick={close}
+                >
+                  {t('modalCancel')}
+                </Button>
+              </Box>
+            </Box>
+          </form>
+        );
+      }}
+    </Formik>
+  );
+}

--- a/src/components/ui/modals/IframeModal.tsx
+++ b/src/components/ui/modals/IframeModal.tsx
@@ -1,16 +1,45 @@
+import { useEffect, useState } from 'react';
+import { decodeTransactionsWithABI } from '../../../helpers/transactionDecoder';
+import { useABI } from '../../../hooks/utils/useABI';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
+import { CreateProposalTransaction } from '../../../types';
 import SafeInjectIframeCard from '../../SafeInjectIframe/SafeInjectIframeCard';
 import { SafeInjectProvider } from '../../SafeInjectIframe/context/SafeInjectProvider';
+import { ModalType } from './ModalProvider';
+import { useDecentModal } from './useDecentModal';
 
 export function IframeModal() {
   const { safe } = useDaoInfoStore();
   const { chain } = useNetworkConfigStore();
+  const { loadABI } = useABI();
+
+  const [decodedTransactions, setDecodedTransactions] = useState<CreateProposalTransaction[]>([]);
+  const openConfirmTransactionModal = useDecentModal(ModalType.CONFIRM_TRANSACTION, {
+    transactionArray: decodedTransactions,
+  });
+
+  useEffect(() => {
+    if (decodedTransactions.length > 0) {
+      openConfirmTransactionModal();
+    }
+  }, [decodedTransactions, openConfirmTransactionModal]);
 
   return (
     <SafeInjectProvider
       defaultAddress={safe?.address}
       chainId={chain.id}
+      onTransactionsReceived={transactions => {
+        (async () => {
+          if (transactions && transactions.length > 0) {
+            const { decodedTransactions: decoded } = await decodeTransactionsWithABI(
+              transactions,
+              loadABI,
+            );
+            setDecodedTransactions(decoded);
+          }
+        })();
+      }}
     >
       <SafeInjectIframeCard />
     </SafeInjectProvider>

--- a/src/components/ui/modals/IframeModal.tsx
+++ b/src/components/ui/modals/IframeModal.tsx
@@ -14,8 +14,10 @@ export function IframeModal() {
   const { chain } = useNetworkConfigStore();
   const { loadABI } = useABI();
 
+  const [connectAppUrl, setConnectAppUrl] = useState<string>('Unknown');
   const [decodedTransactions, setDecodedTransactions] = useState<CreateProposalTransaction[]>([]);
   const openConfirmTransactionModal = useDecentModal(ModalType.CONFIRM_TRANSACTION, {
+    appName: connectAppUrl, // url can be a key to real appName in future
     transactionArray: decodedTransactions,
   });
 
@@ -39,6 +41,9 @@ export function IframeModal() {
             setDecodedTransactions(decoded);
           }
         })();
+      }}
+      onAppConnected={url => {
+        setConnectAppUrl(url);
       }}
     >
       <SafeInjectIframeCard />

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -106,6 +106,7 @@ export type ModalPropsTypes = {
   };
   [ModalType.IFRAME]: {};
   [ModalType.CONFIRM_TRANSACTION]: {
+    appName: string;
     transactionArray: CreateProposalTransaction[];
   };
 };
@@ -318,6 +319,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         modalTitle = t('confirmTransactionTitle');
         modalContent = (
           <ConfirmTransactionModal
+            appName={current.props.appName}
             transactionArray={current.props.transactionArray}
             close={closeModal}
           />

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -2,7 +2,7 @@ import { Portal, Show, useDisclosure } from '@chakra-ui/react';
 import { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address } from 'viem';
-import { ProposalTemplate } from '../../../types';
+import { CreateProposalTransaction, ProposalTemplate } from '../../../types';
 import { SendAssetsData } from '../../../utils/dao/prepareSendAssetsActionData';
 import AddSignerModal from '../../SafeSettings/Signers/modals/AddSignerModal';
 import RemoveSignerModal from '../../SafeSettings/Signers/modals/RemoveSignerModal';
@@ -11,6 +11,7 @@ import AddStrategyPermissionModal from './AddStrategyPermissionModal';
 import { AirdropData, AirdropModal } from './AirdropModal/AirdropModal';
 import { ConfirmDeleteStrategyModal } from './ConfirmDeleteStrategyModal';
 import { ConfirmModifyGovernanceModal } from './ConfirmModifyGovernanceModal';
+import { ConfirmTransactionModal } from './ConfirmTransactionModal';
 import { ConfirmUrlModal } from './ConfirmUrlModal';
 import { DelegateModal } from './DelegateModal';
 import ForkProposalTemplateModal from './ForkProposalTemplateModal';
@@ -43,6 +44,7 @@ export enum ModalType {
   AIRDROP,
   REFILL_GAS,
   IFRAME,
+  CONFIRM_TRANSACTION,
 }
 
 export type CurrentModal = {
@@ -103,6 +105,9 @@ export type ModalPropsTypes = {
     showNonceInput: boolean;
   };
   [ModalType.IFRAME]: {};
+  [ModalType.CONFIRM_TRANSACTION]: {
+    transactionArray: CreateProposalTransaction[];
+  };
 };
 
 export interface IModalContext {
@@ -307,6 +312,17 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         break;
       case ModalType.IFRAME:
         modalContent = <IframeModal />;
+        modalSize = 'xl';
+        break;
+      case ModalType.CONFIRM_TRANSACTION:
+        modalTitle = t('confirmTransactionTitle');
+        modalContent = (
+          <ConfirmTransactionModal
+            transactionArray={current.props.transactionArray}
+            close={closeModal}
+          />
+        );
+        modalSize = 'xl';
         break;
       case ModalType.NONE:
       default:

--- a/src/helpers/transactionDecoder.ts
+++ b/src/helpers/transactionDecoder.ts
@@ -1,0 +1,60 @@
+import { AbiFunction, decodeFunctionData, getAbiItem, Hash } from 'viem';
+import { TransactionWithId } from '../components/SafeInjectIframe/types';
+import { ABIElement } from '../hooks/utils/useABI';
+import { CreateProposalTransaction } from '../types';
+
+interface TransactionsDecodeResult {
+  decodedTransactions: CreateProposalTransaction[];
+  failedTransactions: TransactionWithId[];
+}
+
+/**
+ * Decode transactions with encoded data and ABI
+ * @param transactions which has encoded data
+ * @param loadABI function to load ABI for a given address
+ */
+export async function decodeTransactionsWithABI(
+  transactions: TransactionWithId[],
+  loadABI: (address: string) => Promise<ABIElement[]>,
+): Promise<TransactionsDecodeResult> {
+  const decodedTransactions: CreateProposalTransaction[] = [];
+  const failedTransactions: TransactionWithId[] = [];
+
+  for (const transaction of transactions) {
+    const functionSelector = transaction.data.slice(0, 10);
+    const abi = await loadABI(transaction.to);
+    const abiFunction = getAbiItem({
+      abi: abi,
+      name: functionSelector,
+    }) as AbiFunction;
+
+    // is there ABI for this transaction?
+    if (abiFunction) {
+      // decode parameters from data
+      const { args: paramValues } = decodeFunctionData({
+        abi,
+        data: transaction.data as Hash,
+      });
+      const parameters = abiFunction.inputs.map((abiInput, index) => ({
+        signature: `${abiInput.type} ${abiInput.name}`,
+        label: '',
+        value: paramValues?.[index]!.toString() || '',
+      }));
+
+      decodedTransactions.push({
+        targetAddress: transaction.to || '',
+        functionName: abiFunction.name,
+        ethValue: {
+          value: transaction.value,
+          bigintValue: BigInt(transaction.value),
+        },
+        parameters,
+      });
+    } else {
+      console.warn('loadABIandMatch.fail', { transaction, abi, abiFunction });
+      failedTransactions.push(transaction);
+    }
+  }
+
+  return { decodedTransactions, failedTransactions };
+}

--- a/src/hooks/utils/useABI.ts
+++ b/src/hooks/utils/useABI.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import detectProxyTarget from 'evm-proxy-detection';
+import { useCallback, useEffect, useState } from 'react';
+import { isAddress } from 'viem';
+import { logError } from '../../helpers/errorLogging';
+import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
+import { useNetworkEnsAddress } from '../useNetworkEnsAddress';
+import useNetworkPublicClient from '../useNetworkPublicClient';
+
+export type ABIElement = {
+  type: 'function' | 'constructor' | 'fallback' | 'event';
+  name: string;
+  stateMutability: 'view' | 'nonpayable' | 'pure';
+  inputs: { type: string; name: string; internalType: string }[];
+};
+
+export function useABI(target?: string) {
+  const [abi, setABI] = useState<ABIElement[]>([]);
+  const { etherscanAPIUrl, chain } = useNetworkConfigStore();
+  const { data: ensAddress } = useNetworkEnsAddress({
+    name: target?.toLowerCase(),
+    chainId: chain.id,
+  });
+  const client = useNetworkPublicClient();
+  const loadABI = useCallback(
+    async (targetAddress?: string): Promise<ABIElement[]> => {
+      const address = targetAddress || target;
+      if (address && ((ensAddress && isAddress(ensAddress)) || isAddress(address))) {
+        try {
+          const requestFunc = ({ method, params }: { method: any; params: any }) =>
+            client.request({ method, params });
+
+          const implementationAddress = await detectProxyTarget(ensAddress || address, requestFunc);
+
+          const response = await axios.get(
+            `${etherscanAPIUrl}&module=contract&action=getabi&address=${implementationAddress || ensAddress || address}`,
+          );
+          const responseData = response.data;
+
+          if (responseData.status === '1') {
+            const fetchedABI = JSON.parse(responseData.result);
+            setABI(fetchedABI);
+            return fetchedABI;
+          } else {
+            setABI([]);
+            return [];
+          }
+        } catch (e) {
+          setABI([]);
+          logError(e, 'Error fetching ABI for smart contract');
+          return [];
+        }
+      } else {
+        setABI([]);
+        return [];
+      }
+    },
+    [target, ensAddress, etherscanAPIUrl, client],
+  );
+
+  useEffect(() => {
+    loadABI();
+  }, [loadABI]);
+
+  return { abi, loadABI };
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -22,6 +22,7 @@
   "shutter": "Shutter",
   "send": "Send",
   "transfer": "Transfer",
+  "dappIntegration": "[{{appName}} Integration]",
   "received": "Received",
   "to": "To",
   "from": "From",

--- a/src/i18n/locales/en/modals.json
+++ b/src/i18n/locales/en/modals.json
@@ -59,5 +59,6 @@
   "dragDropCSV": "Drag & drop a .csv file here, or click to select one",
   "dropCSVHere": "Drop CSV here",
   "csvFormat": "address,amount one entry per row",
-  "pasteMultipleRecipients": "You can paste one or multiple recipients (address,amount one entry per row)"
+  "pasteMultipleRecipients": "You can paste one or multiple recipients (address,amount one entry per row)",
+  "confirmTransactionTitle": "Confirm transaction"
 }

--- a/src/types/proposalBuilder.ts
+++ b/src/types/proposalBuilder.ts
@@ -61,7 +61,7 @@ export enum ProposalActionType {
   NATIVE_TRANSFER = 'native_transfer',
   AIRDROP = 'airdrop',
   WITHDRAW_STREAM = 'withdraw_stream',
-  DAPP_INTERACTION = 'dapp_interaction',
+  DAPP_INTEGRATION = 'dapp_integration',
 }
 
 export type CreateProposalActionData<T = BigIntValuePair> = {

--- a/src/types/proposalBuilder.ts
+++ b/src/types/proposalBuilder.ts
@@ -61,6 +61,7 @@ export enum ProposalActionType {
   NATIVE_TRANSFER = 'native_transfer',
   AIRDROP = 'airdrop',
   WITHDRAW_STREAM = 'withdraw_stream',
+  DAPP_INTERACTION = 'dapp_interaction',
 }
 
 export type CreateProposalActionData<T = BigIntValuePair> = {


### PR DESCRIPTION
### Changes

- new modal `ConfirmTransactionModal` that list all transactions from dApp, navigate to proposalWithAction page if user choose to continue.
- new callback `onTransactionsReceived` in props of `SafeInjectProvider`
- updated `IframeModal` to decode transactions within `onTransactionReceived` and then open `ConfirmTransactionModal`
- new action and action card for `DAPP_INTEGRATION`, which display dapp name. (it's now only app url, once we got `dapp.json` imported in later PR, we can display app name easily.)

### Screenshots
#### 1. Confirm transaction modal
<img width="598" alt="image" src="https://github.com/user-attachments/assets/4f2292fd-2110-4a6a-b212-2fde023e6d0b" />

#### 2. Create proposal page with action attached (dApp transactions)
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/2b52297b-d9ca-44ac-bea0-1fdf5c273064" />

