### PR TITLE
`[ENG-408]` Update `getStorageAt` slot for Safe Guard

### DIFF
--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -184,7 +184,8 @@ class EnhancedSafeApiKit {
       });
 
       // Fetch guard using getStorageAt
-      const GUARD_STORAGE_SLOT = '0x3a'; // Slot defined in Safe contracts (could vary)
+      const GUARD_STORAGE_SLOT =
+        '0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8';
       const guardStorageValue = await this.publicClient.getStorageAt({
         address: checksummedSafeAddress,
         slot: GUARD_STORAGE_SLOT,


### PR DESCRIPTION
Closes [ENG-408](https://linear.app/decent-labs/issue/ENG-408/wrong-storage-slot-for-safe-contract)

noticed the guard wasn't loading correct as I was not pointing to the correct storage location

## Screenshot
![localhost_3000_home_dao=sep%3A0xE5a5bD9739Ab39C563C9FE8b3036feEFb7C8E5bA page=1 size=10(Desktop)](https://github.com/user-attachments/assets/951c9999-43cb-4484-a169-26207096ff6b)
