### PR TITLE
`[ENG-237]` prevent freeze option from showing on parent dao

### DIFF
--- a/src/hooks/DAO/loaders/useFractalFreeze.ts
+++ b/src/hooks/DAO/loaders/useFractalFreeze.ts
@@ -192,12 +192,28 @@ export const useFractalFreeze = ({
 
   const setFractalFreezeGuard = useCallback(
     async (_guardContracts: FractalGuardContracts) => {
-      const freezeGuard = await loadFractalFreezeGuard(_guardContracts);
-      if (freezeGuard) {
-        action.dispatch({ type: FractalGuardAction.SET_FREEZE_GUARD, payload: freezeGuard });
+      if (parentSafeAddress) {
+        const freezeGuard = await loadFractalFreezeGuard(_guardContracts);
+        if (freezeGuard) {
+          action.dispatch({ type: FractalGuardAction.SET_FREEZE_GUARD, payload: freezeGuard });
+        }
+      } else {
+        action.dispatch({
+          type: FractalGuardAction.SET_FREEZE_GUARD,
+          payload: {
+            freezeVotesThreshold: null,
+            freezeProposalCreatedTime: null,
+            freezeProposalVoteCount: null,
+            freezeProposalPeriod: null,
+            freezePeriod: null,
+            userHasFreezeVoted: false,
+            isFrozen: false,
+            userHasVotes: false,
+          },
+        });
       }
     },
-    [action, loadFractalFreezeGuard],
+    [action, loadFractalFreezeGuard, parentSafeAddress],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Closes [ENG-237](https://linear.app/decent-labs/issue/ENG-237/initiate-a-freeze-option-can-appear-for-parent-dao)

Tested with ERC20 and Multisig type DAOs

## Screenshot
![localhost_3000_home_dao=sep%3A0xc4065900f43f9552b43f54cefe7f718b2c765707 page=1 size=10(Desktop)](https://github.com/user-attachments/assets/f3bafb29-ff65-445f-a75b-48419f7d285c)
