### PR TITLE
`[ENG-256]` Ensure claim banner doesn't persist after being set.

### DIFF
--- a/src/components/DaoDashboard/ERC20Claim.tsx
+++ b/src/components/DaoDashboard/ERC20Claim.tsx
@@ -28,6 +28,10 @@ export function ERCO20Claim() {
     if (!tokenClaimContractAddress || !type || !account) {
       return;
     }
+    if (!tokenClaimContractAddress) {
+      setUserClaimable(0n);
+      return;
+    }
     const tokenClaimContract = getContract({
       abi: abis.ERC20Claim,
       address: tokenClaimContractAddress,


### PR DESCRIPTION
Closes [ENG-256](https://linear.app/decent-labs/issue/ENG-256/token-claiming-banner-does-not-clear-on-first-load-of-different-dao)
