### PR TITLE
`[ENG-370]` update user rejection logic (part 2)

### DIFF
--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -209,11 +209,12 @@ export default function useSubmitProposal() {
         toast.success(successToastMessage, { id: toastId });
       } catch (e: any) {
         // @dev we do not want to log user denied transaction
+        // @dev we do not want to log user denied transaction
         if (
           // viem error
-          (e as ContractFunctionExecutionError).shortMessage === 'User rejected the request.' ||
+          (e as ContractFunctionExecutionError)?.shortMessage === 'User rejected the request.' ||
           // metamask code error
-          (e as ProviderRpcError).code === 4001
+          (e as ProviderRpcError)?.code === 4001
         ) {
           toast.dismiss(toastId);
           toast.info(t('errorUserDeniedTransaction', { ns: 'transaction', id: toastId }));

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -209,7 +209,6 @@ export default function useSubmitProposal() {
         toast.success(successToastMessage, { id: toastId });
       } catch (e: any) {
         // @dev we do not want to log user denied transaction
-        // @dev we do not want to log user denied transaction
         if (
           // viem error
           (e as ContractFunctionExecutionError)?.shortMessage === 'User rejected the request.' ||

--- a/src/hooks/utils/useTransaction.ts
+++ b/src/hooks/utils/useTransaction.ts
@@ -55,16 +55,16 @@ const useTransaction = () => {
             setPending(false);
           }, 2000);
         })
-        .catch((error: ContractFunctionExecutionError | ProviderRpcError) => {
+        .catch((error: any) => {
           setPending(false);
 
           // @dev we do not want to log user denied transaction
           if (
             // viem error
-            (error as ContractFunctionExecutionError).shortMessage ===
+            (error as ContractFunctionExecutionError)?.shortMessage ===
               'User rejected the request.' ||
             // metamask code error
-            (error as ProviderRpcError).code === 4001
+            (error as ProviderRpcError)?.code === 4001
           ) {
             toast.dismiss(toastId);
             toast.info(t('errorUserDeniedTransaction', { ns: 'transaction', id: toastId }));

--- a/src/hooks/utils/useTransaction.ts
+++ b/src/hooks/utils/useTransaction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { Hash, TransactionReceipt } from 'viem';
+import { ContractFunctionExecutionError, Hash, TransactionReceipt } from 'viem';
 import { logError } from '../../helpers/errorLogging';
 import useNetworkPublicClient from '../useNetworkPublicClient';
 
@@ -55,11 +55,19 @@ const useTransaction = () => {
             setPending(false);
           }, 2000);
         })
-        .catch((error: ProviderRpcError) => {
+        .catch((error: ContractFunctionExecutionError | ProviderRpcError) => {
           setPending(false);
 
-          if (error.code === 4001) {
-            toast.info(t('errorUserDeniedTransaction', { id: toastId }));
+          // @dev we do not want to log user denied transaction
+          if (
+            // viem error
+            (error as ContractFunctionExecutionError).shortMessage ===
+              'User rejected the request.' ||
+            // metamask code error
+            (error as ProviderRpcError).code === 4001
+          ) {
+            toast.dismiss(toastId);
+            toast.info(t('errorUserDeniedTransaction', { ns: 'transaction', id: toastId }));
             return;
           }
           logError(error);


### PR DESCRIPTION
Closes fully [ENG-370](https://github.com/decentdao/decent-app/compare/eng-370-update-user-rejected-error-handling-part-2?expand=1)

Covers these other areas mentioned in this comment https://linear.app/decent-labs/issue/ENG-370/sentry-transactionexecutionerror-user-rejected-the-request#comment-d6fac422

