### PR TITLE
`[ENG-429]` Remove `nonceInput` from action modals; Allow actionsProposal to have transactions step which has nonce input

### DIFF
--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -143,7 +143,6 @@ export function GaslessVotingToggleDAOSettings(
       const action = prepareRefillPaymasterActionData({
         refillAmount: refillGasData.transferAmount,
         paymasterAddress,
-        nonceInput: refillGasData.nonceInput,
         nativeToken: {
           decimals: nativeTokenBalance?.decimals ?? 18,
           symbol: nativeTokenBalance?.symbol ?? 'Native Token',
@@ -154,7 +153,6 @@ export function GaslessVotingToggleDAOSettings(
 
       navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safe.address));
     },
-    showNonceInput: true,
   });
 
   const { data: balance } = useBalance({ address: paymasterAddress, chainId: chain.id });

--- a/src/components/ProposalBuilder/ProposalActionCard.tsx
+++ b/src/components/ProposalBuilder/ProposalActionCard.tsx
@@ -63,7 +63,6 @@ function SendAssetsAction({
         recipientAddress,
         transferAmount,
         asset,
-        nonceInput: undefined,
       }}
       onRemove={onRemove}
     />

--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -126,7 +126,6 @@ export function AddActions({
       >
         <SendAssetsModal
           submitButtonText={t('add', { ns: 'modals' })}
-          showNonceInput={false}
           close={onCloseAssets}
           sendAssetsData={addSendAssetsAction}
         />

--- a/src/components/ui/modals/AirdropModal/AirdropModal.tsx
+++ b/src/components/ui/modals/AirdropModal/AirdropModal.tsx
@@ -1,19 +1,16 @@
 import { Box, Button, Flex, HStack, IconButton, Select, Text } from '@chakra-ui/react';
 import { CaretDown, MinusCircle, Plus } from '@phosphor-icons/react';
 import { Field, FieldAttributes, FieldProps, Form, Formik } from 'formik';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, getAddress, isAddress } from 'viem';
 import { usePublicClient } from 'wagmi';
 import * as Yup from 'yup';
 import { useFractal } from '../../../../providers/App/AppProvider';
-import { useDaoInfoStore } from '../../../../store/daoInfo/useDaoInfoStore';
 import { BigIntValuePair, TokenBalance } from '../../../../types';
 import { formatCoinFromAsset } from '../../../../utils';
 import { validateENSName } from '../../../../utils/url';
 import NoDataCard from '../../containers/NoDataCard';
 import { BigIntInput } from '../../forms/BigIntInput';
-import { CustomNonceInput } from '../../forms/CustomNonceInput';
 import { AddressInput } from '../../forms/EthAddressInput';
 import LabelWrapper from '../../forms/LabelWrapper';
 import Divider from '../../utils/Divider';
@@ -33,30 +30,25 @@ export interface AirdropData {
     amount: bigint;
   }[];
   asset: TokenBalance;
-  nonceInput: number | undefined; // this is only releveant when the caller action results in a proposal
 }
 
 export function AirdropModal({
   submitButtonText,
-  showNonceInput,
   close,
   airdropData,
 }: {
   submitButtonText: string;
-  showNonceInput: boolean;
   close: () => void;
   airdropData: (airdropData: AirdropData) => void;
 }) {
   const {
     treasury: { assetsFungible },
   } = useFractal();
-  const { safe } = useDaoInfoStore();
 
   const publicClient = usePublicClient();
   const { t } = useTranslation(['modals', 'common']);
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
-  const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nextNonce);
 
   const airdropValidationSchema = Yup.object().shape({
     selectedAsset: Yup.object()
@@ -103,7 +95,6 @@ export function AirdropModal({
         }),
       ),
       asset: values.selectedAsset,
-      nonceInput,
     });
 
     close();
@@ -366,13 +357,6 @@ export function AirdropModal({
               </Box>
 
               <Divider my="1.5rem" />
-
-              {showNonceInput && (
-                <CustomNonceInput
-                  nonce={nonceInput}
-                  onChange={nonce => setNonceInput(nonce ? parseInt(nonce) : undefined)}
-                />
-              )}
 
               <Button
                 marginTop="2rem"

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -93,16 +93,13 @@ export type ModalPropsTypes = {
   [ModalType.SEND_ASSETS]: {
     onSubmit: (sendAssetData: SendAssetsData) => void;
     submitButtonText: string;
-    showNonceInput: boolean;
   };
   [ModalType.AIRDROP]: {
     onSubmit: (airdropData: AirdropData) => void;
     submitButtonText: string;
-    showNonceInput: boolean;
   };
   [ModalType.REFILL_GAS]: {
     onSubmit: (refillGasData: RefillGasData) => void;
-    showNonceInput: boolean;
   };
   [ModalType.IFRAME]: {};
   [ModalType.CONFIRM_TRANSACTION]: {
@@ -277,7 +274,6 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         modalContent = (
           <SendAssetsModal
             submitButtonText={current.props.submitButtonText}
-            showNonceInput={current.props.showNonceInput}
             close={closeModal}
             sendAssetsData={(data: SendAssetsData) => {
               current.props.onSubmit(data);
@@ -289,7 +285,6 @@ export function ModalProvider({ children }: { children: ReactNode }) {
       case ModalType.REFILL_GAS:
         modalContent = (
           <RefillGasTankModal
-            showNonceInput={current.props.showNonceInput}
             close={closeModal}
             refillGasData={(data: RefillGasData) => {
               current.props.onSubmit(data);
@@ -302,7 +297,6 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         modalContent = (
           <AirdropModal
             submitButtonText={current.props.submitButtonText}
-            showNonceInput={current.props.showNonceInput}
             close={closeModal}
             airdropData={(data: AirdropData) => {
               current.props.onSubmit(data);

--- a/src/components/ui/modals/RefillGasTankModal.tsx
+++ b/src/components/ui/modals/RefillGasTankModal.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, CloseButton, Flex, Text } from '@chakra-ui/react';
 import { Field, FieldAttributes, FieldProps, Form, Formik } from 'formik';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useBalance } from 'wagmi';
 import * as Yup from 'yup';
@@ -9,7 +8,6 @@ import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
 import { BigIntValuePair } from '../../../types';
 import { formatCoinUnits } from '../../../utils/numberFormats';
 import { BigIntInput } from '../forms/BigIntInput';
-import { CustomNonceInput } from '../forms/CustomNonceInput';
 import LabelWrapper from '../forms/LabelWrapper';
 import { AssetSelector } from '../utils/AssetSelector';
 
@@ -19,15 +17,12 @@ interface RefillGasFormValues {
 
 export interface RefillGasData {
   transferAmount: bigint;
-  nonceInput: number | undefined;
 }
 
 export function RefillGasTankModal({
-  showNonceInput,
   close,
   refillGasData,
 }: {
-  showNonceInput: boolean;
   close: () => void;
   refillGasData: (refillData: RefillGasData) => void;
 }) {
@@ -37,8 +32,6 @@ export function RefillGasTankModal({
   });
 
   const { t } = useTranslation('gaslessVoting');
-
-  const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nextNonce);
 
   const { isValidating } = useValidationAddress();
 
@@ -53,7 +46,6 @@ export function RefillGasTankModal({
   const handleRefillGasSubmit = async (values: RefillGasFormValues) => {
     refillGasData({
       transferAmount: values.inputAmount?.bigintValue || 0n,
-      nonceInput,
     });
 
     close();
@@ -158,13 +150,6 @@ export function RefillGasTankModal({
                   </Flex>
                 </Flex>
               </Flex>
-
-              {showNonceInput && (
-                <CustomNonceInput
-                  nonce={nonceInput}
-                  onChange={nonce => setNonceInput(nonce ? parseInt(nonce) : undefined)}
-                />
-              )}
 
               <Flex
                 marginTop="2rem"

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -1,21 +1,18 @@
 import { Box, Button, Flex, HStack, Select, Text } from '@chakra-ui/react';
 import { CaretDown } from '@phosphor-icons/react';
 import { Field, FieldAttributes, FieldProps, Form, Formik } from 'formik';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getAddress } from 'viem';
 import * as Yup from 'yup';
 import { useValidationAddress } from '../../../hooks/schemas/common/useValidationAddress';
 import { useNetworkEnsAddressAsync } from '../../../hooks/useNetworkEnsAddress';
 import { useFractal } from '../../../providers/App/AppProvider';
-import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
 import { BigIntValuePair, TokenBalance } from '../../../types';
 import { SendAssetsData } from '../../../utils/dao/prepareSendAssetsActionData';
 import { formatCoinFromAsset, formatCoinUnits } from '../../../utils/numberFormats';
 import { validateENSName } from '../../../utils/url';
 import NoDataCard from '../containers/NoDataCard';
 import { BigIntInput } from '../forms/BigIntInput';
-import { CustomNonceInput } from '../forms/CustomNonceInput';
 import { AddressInput } from '../forms/EthAddressInput';
 import LabelWrapper from '../forms/LabelWrapper';
 import Divider from '../utils/Divider';
@@ -28,25 +25,21 @@ interface SendAssetsFormValues {
 
 export function SendAssetsModal({
   submitButtonText,
-  showNonceInput,
   close,
   sendAssetsData,
 }: {
   submitButtonText: string;
-  showNonceInput: boolean;
   close: () => void;
   sendAssetsData: (sendAssetData: SendAssetsData) => void;
 }) {
   const {
     treasury: { assetsFungible },
   } = useFractal();
-  const { safe } = useDaoInfoStore();
 
   const { getEnsAddress } = useNetworkEnsAddressAsync();
   const { t } = useTranslation(['modals', 'common']);
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
-  const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nextNonce);
 
   const { addressValidationTest, isValidating } = useValidationAddress();
 
@@ -82,7 +75,6 @@ export function SendAssetsModal({
       transferAmount: values.inputAmount?.bigintValue || 0n,
       asset: values.selectedAsset,
       recipientAddress: getAddress(destAddress),
-      nonceInput,
     });
 
     close();
@@ -228,13 +220,6 @@ export function SendAssetsModal({
               </Field>
 
               <Divider my="1.5rem" />
-
-              {showNonceInput && (
-                <CustomNonceInput
-                  nonce={nonceInput}
-                  onChange={nonce => setNonceInput(nonce ? parseInt(nonce) : undefined)}
-                />
-              )}
 
               <Button
                 marginTop="2rem"

--- a/src/hooks/DAO/useSendAssetsActionModal.tsx
+++ b/src/hooks/DAO/useSendAssetsActionModal.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { ModalType } from '../../components/ui/modals/ModalProvider';
 import { useDecentModal } from '../../components/ui/modals/useDecentModal';
 import { DAO_ROUTES } from '../../constants/routes';
-import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { useProposalActionsStore } from '../../store/actions/useProposalActionsStore';
 import { useDaoInfoStore } from '../../store/daoInfo/useDaoInfoStore';
@@ -19,9 +18,7 @@ export default function useSendAssetsActionModal() {
   const { t } = useTranslation(['modals']);
   const { addAction } = useProposalActionsStore();
   const navigate = useNavigate();
-  const {
-    governance: { isAzorius },
-  } = useFractal();
+
   const sendAssetsAction = async (sendAssetsData: SendAssetsData) => {
     if (!safe?.address) {
       return;
@@ -36,7 +33,6 @@ export default function useSendAssetsActionModal() {
   const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsAction,
     submitButtonText: t('submitProposal', { ns: 'modals' }),
-    showNonceInput: !isAzorius,
   });
 
   return {

--- a/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
+++ b/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
@@ -97,7 +97,6 @@ export function SafeProposalTemplatesPage() {
   const openAirdropModal = useDecentModal(ModalType.AIRDROP, {
     onSubmit: handleAirdropSubmit,
     submitButtonText: t('submitProposal', { ns: 'modals' }),
-    showNonceInput: false,
   });
 
   const EXAMPLE_TEMPLATES = useMemo(() => {

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -8,7 +8,7 @@ import { ProposalBuilder } from '../../../../../components/ProposalBuilder/Propo
 import { TransactionsDetails } from '../../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import { CreateProposalButton } from '../../../../../components/ProposalBuilder/StepButtons';
+import { GoToTransactionsStepButton } from '../../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { AddActions } from '../../../../../components/ui/modals/AddActions';
@@ -115,11 +115,18 @@ export function SafeProposalWithActionsCreatePage() {
   };
 
   const stepButtons = ({
-    createProposalBlocked,
+    formErrors,
+    onStepChange,
   }: {
+    formErrors: boolean;
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => <CreateProposalButton isDisabled={createProposalBlocked} />;
+  }) => (
+    <GoToTransactionsStepButton
+      isDisabled={formErrors}
+      onStepChange={onStepChange}
+    />
+  );
 
   return (
     <ProposalBuilder

--- a/src/utils/dao/prepareRefillPaymasterActionData.ts
+++ b/src/utils/dao/prepareRefillPaymasterActionData.ts
@@ -5,7 +5,6 @@ import { formatCoin } from '../numberFormats';
 export interface RefillPaymasterData {
   paymasterAddress: Address;
   refillAmount: bigint;
-  nonceInput: number | undefined; // this is only releveant when the caller action results in a proposal
   nativeToken: {
     decimals: number;
     symbol: string;

--- a/src/utils/dao/prepareSendAssetsActionData.ts
+++ b/src/utils/dao/prepareSendAssetsActionData.ts
@@ -6,7 +6,6 @@ export interface SendAssetsData {
   recipientAddress: Address;
   transferAmount: bigint;
   asset: TokenBalance;
-  nonceInput: number | undefined; // this is only releveant when the caller action results in a proposal
 }
 
 interface ActionData {


### PR DESCRIPTION
### Why do we need to do this?

- actions has `nonceInput` parameter while actionStore only store `actionType` `transactions` and `content`, so `nonceInput` is actually not passed to `ProposalBuilder`
- CreateProposalWithActions page was skipping "Transactions" step, we want it back which I believe it's a standard way to use `ProposalBuilder`.

### Screenshots

#### Send assets template no longer has "Custom Nonce" input
<img width="548" alt="image" src="https://github.com/user-attachments/assets/e8c6f026-16c2-4ed0-a394-df477719277c" />

#### Proposal create with actions can now go to next step instead of skip and create proposal directly
<img width="842" alt="image" src="https://github.com/user-attachments/assets/97edd762-4328-4e92-9e70-8c7712a5137d" />

#### Reviewing all transactions and specify custom nonce in last step
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/0df0fcda-dd6c-47fb-b265-15b37c54d77d" />
