### PR TITLE
`[ENG-444]` Update Voter Actions UX

### DIFF
--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -63,9 +63,9 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
   );
 
   const isRejectedProposalPassThreshold =
-    rejectionProposal &&
-    rejectionProposal.confirmations &&
-    rejectionProposal.signersThreshold &&
+    !!rejectionProposal &&
+    !!rejectionProposal.confirmations &&
+    !!rejectionProposal.signersThreshold &&
     rejectionProposal.confirmations.length >= rejectionProposal.signersThreshold;
 
   const isOwner = safe?.owners?.includes(userAccount.address ?? zeroAddress);


### PR DESCRIPTION
Closes [ENG-444](https://linear.app/decent-labs/issue/ENG-444/allow-reject-even-if-approval-threshold-has-been-reached)

As well as this short series. I hope

## Screenshot

![localhost_3000_proposals_0x8a0aed01dcc928ed9ed2b0fce9591349ca4f3c7287cff1960d414e55f6d83977_dao=sep_0x40584Ef308e7317BcaF086dB60cCA926c08d81c1 (1)](https://github.com/user-attachments/assets/12bb2bf8-4edb-4dab-ba3f-2dcc89fa8e45)


## Note
So the UI as is left to be wanting. These components are wrapped in `ContentBox` which is used in a few different places. But isn't alof ot properties, easily make a new container component for these two sections so they don't look so weirdly separate 