### PR TITLE
`eng 459` paymaster deploymemt bug

### DIFF
--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -23,7 +23,7 @@ const getGaslessVotingDaoData = async (
     .pop();
 
   if (!gaslessVotingEnabledEvent) {
-    return;
+    return { gaslessVotingEnabled: false, paymasterAddress: null };
   }
 
   try {


### PR DESCRIPTION
A recent update to deciding if paymaster exists or not (`paymaster` === `null`) led to a bug that made the app think paymaster was already deployed when enabling gasless voting, because `paymaster` was never set on app load when there have been no gasless voting related keyvaluepair contract events.

Closes ENG-459