### PR TITLE
Rename master copy variables for new strategy addresses

### DIFF
--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -105,8 +105,8 @@ export default function useCreateRoles() {
       erc6551Registry,
       keyValuePairs,
       sablierV2LockupLinear,
-      linearVotingErc20V1HatsWhitelistingMasterCopy,
-      linearVotingErc721V1HatsWhitelistingMasterCopy,
+      linearVotingErc20HatsWhitelistingV1MasterCopy,
+      linearVotingErc721HatsWhitelistingV1MasterCopy,
       zodiacModuleProxyFactory,
       decentAutonomousAdminV1MasterCopy,
       hatsElectionsEligibilityMasterCopy,
@@ -188,7 +188,7 @@ export default function useCreateRoles() {
             abi: ZodiacModuleProxyFactoryAbi,
             functionName: 'deployModule',
             args: [
-              linearVotingErc20V1HatsWhitelistingMasterCopy,
+              linearVotingErc20HatsWhitelistingV1MasterCopy,
               encodedStrategySetupData,
               strategyNonce,
             ],
@@ -197,7 +197,7 @@ export default function useCreateRoles() {
         };
 
         const strategyByteCodeLinear = generateContractByteCodeLinear(
-          linearVotingErc20V1HatsWhitelistingMasterCopy,
+          linearVotingErc20HatsWhitelistingV1MasterCopy,
         );
 
         const strategySalt = keccak256(
@@ -281,7 +281,7 @@ export default function useCreateRoles() {
             abi: ZodiacModuleProxyFactoryAbi,
             functionName: 'deployModule',
             args: [
-              linearVotingErc721V1HatsWhitelistingMasterCopy,
+              linearVotingErc721HatsWhitelistingV1MasterCopy,
               encodedStrategySetupData,
               strategyNonce,
             ],
@@ -290,7 +290,7 @@ export default function useCreateRoles() {
         };
 
         const strategyByteCodeLinear = generateContractByteCodeLinear(
-          linearVotingErc721V1HatsWhitelistingMasterCopy,
+          linearVotingErc721HatsWhitelistingV1MasterCopy,
         );
 
         const strategySalt = keccak256(
@@ -326,8 +326,8 @@ export default function useCreateRoles() {
       safeAddress,
       governance,
       hatsProtocol,
-      linearVotingErc20V1HatsWhitelistingMasterCopy,
-      linearVotingErc721V1HatsWhitelistingMasterCopy,
+      linearVotingErc20HatsWhitelistingV1MasterCopy,
+      linearVotingErc721HatsWhitelistingV1MasterCopy,
       moduleAzoriusAddress,
       publicClient,
       zodiacModuleProxyFactory,

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -70,9 +70,9 @@ export const baseConfig: NetworkConfig = {
     ),
 
     linearVotingErc20V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc20V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc20HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
     linearVotingErc721V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc721V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc721HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -70,9 +70,9 @@ export const mainnetConfig: NetworkConfig = {
     ),
 
     linearVotingErc20V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc20V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc20HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
     linearVotingErc721V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc721V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc721HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -70,9 +70,9 @@ export const optimismConfig: NetworkConfig = {
     ),
 
     linearVotingErc20V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc20V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc20HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
     linearVotingErc721V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc721V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc721HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -70,9 +70,9 @@ export const polygonConfig: NetworkConfig = {
     ),
 
     linearVotingErc20V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc20V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc20HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
     linearVotingErc721V1MasterCopy: '0x0000000000000000000000000000000000000000',
-    linearVotingErc721V1HatsWhitelistingMasterCopy: '0x0000000000000000000000000000000000000000',
+    linearVotingErc721HatsWhitelistingV1MasterCopy: '0x0000000000000000000000000000000000000000',
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -70,9 +70,9 @@ export const sepoliaConfig: NetworkConfig = {
     ),
 
     linearVotingErc20V1MasterCopy: '0xFe3542A836789c1b54B7A1De2ADfceC5F7f0425a',
-    linearVotingErc20V1HatsWhitelistingMasterCopy: '0x7EA0e76FC3c5447912646734595C5AB743415128',
+    linearVotingErc20HatsWhitelistingV1MasterCopy: '0x7EA0e76FC3c5447912646734595C5AB743415128',
     linearVotingErc721V1MasterCopy: '0xd0C8E17d512eb8582431fC856DD49E1c3CCE0CDa',
-    linearVotingErc721V1HatsWhitelistingMasterCopy: '0x0aC793E3d815E3bE2acED189019af5C5Cde8E5B2',
+    linearVotingErc721HatsWhitelistingV1MasterCopy: '0x0aC793E3d815E3bE2acED189019af5C5Cde8E5B2',
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -38,9 +38,9 @@ export type NetworkConfig = {
     linearVotingErc721HatsWhitelistingMasterCopy: Address;
 
     linearVotingErc20V1MasterCopy: Address;
-    linearVotingErc20V1HatsWhitelistingMasterCopy: Address;
+    linearVotingErc20HatsWhitelistingV1MasterCopy: Address;
     linearVotingErc721V1MasterCopy: Address;
-    linearVotingErc721V1HatsWhitelistingMasterCopy: Address;
+    linearVotingErc721HatsWhitelistingV1MasterCopy: Address;
 
     moduleAzoriusMasterCopy: Address;
     moduleFractalMasterCopy: Address;


### PR DESCRIPTION
- Refactor role creation references to use updated naming convention for HatsWhitelisting master copies