### PR TITLE
Bump @fractal-framework/fractal-contracts to 1.5.0-rc.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@fontsource/space-mono": "^5.0.19",
-        "@fractal-framework/fractal-contracts": "^1.5.0-rc.2",
+        "@fractal-framework/fractal-contracts": "^1.5.0-rc.3",
         "@hatsprotocol/modules-sdk": "^1.4.0",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
@@ -5674,9 +5674,9 @@
       "integrity": "sha512-gz9yaKtXCY+HutNvQ4APc15xwZ1f6pWXve5N55x5m/hOoGqgB9Auf3l7CitHNhNJkSKEmaM45M29b0rFeudXlg=="
     },
     "node_modules/@fractal-framework/fractal-contracts": {
-      "version": "1.5.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.5.0-rc.2.tgz",
-      "integrity": "sha512-lGd/bqBZdZQ29zHfDwZ8aIt+q81+8NJvQPJFEGGtz3Ty2brGazeFGSAVS5NJ16OhkkzIkJnvMKFm/FVLbUhoYQ==",
+      "version": "1.5.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.5.0-rc.3.tgz",
+      "integrity": "sha512-TzDarftBzHGo0HrysjeOjTm8plTaqg/vn4eYPnU2X5rmNRxhXiqIiyDtEQoKI08qXOnjPjI2v8Ktke/cqCQ++Q==",
       "license": "MIT",
       "dependencies": {
         "@account-abstraction/contracts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@fontsource/space-mono": "^5.0.19",
-    "@fractal-framework/fractal-contracts": "^1.5.0-rc.2",
+    "@fractal-framework/fractal-contracts": "^1.5.0-rc.3",
     "@hatsprotocol/modules-sdk": "^1.4.0",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",


### PR DESCRIPTION
We have never actually had a working version of the Paymaster contract.

All testing that's happened so far which "worked", was on a paymaster contract that had no actual validation built into it.

Then within the last day or two a PR was merged into the app which replaced that "hacked" version of the Paymaster with a version that implemented some broken validation logic.

So any new DAOs deployed within the last day or two which enabled gasless voting were using broken Paymaster contracts.

This commit updates the Paymaster contract to the latest version which fixes the validation logic.

So any new DAOs deployed from this PR on will be using a Paymaster contract with proper validation logic for gasless voting via the `execute` function on LightSmartAccount.