### PR TITLE
Add cast vote fallback pending hiFi UX design

### DIFF
--- a/src/components/Proposals/ProposalActions/CastVote.tsx
+++ b/src/components/Proposals/ProposalActions/CastVote.tsx
@@ -128,9 +128,11 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
           onSuccess: gaslessVoteSuccessModal,
           onError: (error: any) => {
             console.error('Gasless voting error:', error);
-            toast.error(t('castVoteError'));
+            toast.error(`${t('castVoteError')}${t('castVoteErrorTempAutoFallback')}`);
 
-            // @todo: (gv) Show a modal to user, give them option to retry, cancel, or pay their own gas to cast vote
+            setTimeout(() => {
+              castVote(selectedVoteChoice);
+            }, 5000);
           },
         });
       } else {

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -191,5 +191,6 @@
   "streamTransferableHelper": "If enabled, the stream can be transferred to another address by the stream's recipient",
   "proposalSummaryNotEnoughVotingPower": "Your voting power did not meet requirements to vote on this proposal when it was created.",
   "proposalSummaryNotEnoughVotingPowerSecondary": "Delegate voting tokens to your address to be eligible to vote on future proposals.",
-  "castVoteError": "Failed to send vote"
+  "castVoteError": "Failed to send vote",
+  "castVoteErrorTempAutoFallback": ". Falling back to paid voting..."
 }


### PR DESCRIPTION
Adds an automatic call to `castVote` on `castGaslessVote` error, after a 5-second delay.
Closes ENG-492