### PR TITLE
Expand types and typescript errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noErrorTruncation": true
   },
   "include": ["src", "tests", "test", "app", "functions", "vite.config.mts"]
 }


### PR DESCRIPTION
This tsconfig flag fully expands types and typescript errors in IDE

before:
![image](https://github.com/user-attachments/assets/a5a7d642-f358-45d2-9af6-202c38d73d57)

after (you get a scroll bar):
![image](https://github.com/user-attachments/assets/f8cb7deb-000f-4e6e-aeef-8ca3ec4e0424)

credit:
https://stackoverflow.com/questions/62059942/how-to-extract-a-large-type-with-vs-code-without-the-19-more-truncate