### PR TITLE
chore: bump @fractal-framework/fractal-contracts to v1.5.0-rc.5 and update mainnet configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@fontsource/space-mono": "^5.0.19",
-        "@fractal-framework/fractal-contracts": "^1.5.0-rc.4",
+        "@fractal-framework/fractal-contracts": "^1.5.0-rc.5",
         "@hatsprotocol/modules-sdk": "^1.4.0",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
@@ -5674,9 +5674,9 @@
       "integrity": "sha512-gz9yaKtXCY+HutNvQ4APc15xwZ1f6pWXve5N55x5m/hOoGqgB9Auf3l7CitHNhNJkSKEmaM45M29b0rFeudXlg=="
     },
     "node_modules/@fractal-framework/fractal-contracts": {
-      "version": "1.5.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.5.0-rc.4.tgz",
-      "integrity": "sha512-ytB2OsjW/nCsaSxMjFyKYNm71YOCdgnS/Ej7wCvg2gw7TlwrtL9tJnFopNR5CmYUpf9iyfZDWUH2BacAzx3inQ==",
+      "version": "1.5.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.5.0-rc.5.tgz",
+      "integrity": "sha512-qc4Uloge2WfvuW/pwd3l/KHLmPy2whBfq28wqc+WHZJmApM1/1MnPYP+uKmnTrwJdjyHPbsUWVmIkrXtLYT49A==",
       "license": "MIT",
       "dependencies": {
         "@account-abstraction/contracts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@fontsource/space-mono": "^5.0.19",
-    "@fractal-framework/fractal-contracts": "^1.5.0-rc.4",
+    "@fractal-framework/fractal-contracts": "^1.5.0-rc.5",
     "@hatsprotocol/modules-sdk": "^1.4.0",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -5,7 +5,7 @@ import {
   getProxyFactoryDeployment,
   getSafeL2SingletonDeployment,
 } from '@safe-global/safe-deployments';
-import { getAddress, zeroAddress } from 'viem';
+import { getAddress } from 'viem';
 import { mainnet } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
@@ -69,10 +69,14 @@ export const mainnetConfig: NetworkConfig = {
       a.LinearERC721VotingWithHatsProposalCreation,
     ),
 
-    linearVotingErc20V1MasterCopy: zeroAddress,
-    linearVotingErc20HatsWhitelistingV1MasterCopy: zeroAddress,
-    linearVotingErc721V1MasterCopy: zeroAddress,
-    linearVotingErc721HatsWhitelistingV1MasterCopy: zeroAddress,
+    linearVotingErc20V1MasterCopy: getAddress(a.LinearERC20VotingV1),
+    linearVotingErc20HatsWhitelistingV1MasterCopy: getAddress(
+      a.LinearERC20VotingWithHatsProposalCreationV1,
+    ),
+    linearVotingErc721V1MasterCopy: getAddress(a.LinearERC721VotingV1),
+    linearVotingErc721HatsWhitelistingV1MasterCopy: getAddress(
+      a.LinearERC721VotingWithHatsProposalCreationV1,
+    ),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),
     moduleFractalMasterCopy: getAddress(a.FractalModule),
@@ -90,7 +94,7 @@ export const mainnetConfig: NetworkConfig = {
 
     decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
 
-    decentPaymasterV1MasterCopy: zeroAddress,
+    decentPaymasterV1MasterCopy: getAddress(a.DecentPaymasterV1),
 
     keyValuePairs: getAddress(a.KeyValuePairs),
 


### PR DESCRIPTION
This commit updates the version of @fractal-framework/fractal-contracts to v1.5.0-rc.5 in both package.json and package-lock.json. Additionally, it modifies the mainnet configuration to replace zeroAddress placeholders with actual contract addresses using the getAddress function, ensuring proper deployment references for linear voting contracts.