### PR TITLE
`ENG-574` | Fix SafesMenu button component by changing its element type to 'div'

### DIFF
--- a/src/components/ui/menus/SafesMenu/index.tsx
+++ b/src/components/ui/menus/SafesMenu/index.tsx
@@ -39,6 +39,7 @@ export function SafesMenu() {
         <OptionMenu
           trigger={
             <Button
+              as="div"
               variant="tertiary"
               alignItems="center"
               gap={2}


### PR DESCRIPTION
Closes ENG-574

Before:
<img width="1178" alt="Screenshot 2025-04-10 at 11 28 44 AM" src="https://github.com/user-attachments/assets/aeb4ead2-2c9f-4f25-864b-cce8c4a9d95a" />

After:
<img width="1178" alt="Screenshot 2025-04-10 at 11 28 54 AM" src="https://github.com/user-attachments/assets/4003baef-d8a6-4232-b15b-9f6fc17b04e1" />
