### PR TITLE
`[ENG-604]` cannot create or fork proposal template

### DIFF
--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -63,7 +63,10 @@ export function SafeCreateProposalTemplatePage() {
                 ...tx,
                 ethValue: {
                   value: tx.ethValue.value,
-                  bigintValue: tx.ethValue.value !== '' ? BigInt(tx.ethValue.value) : undefined,
+                  bigintValue:
+                    tx.ethValue.bigintValue !== undefined
+                      ? BigInt(tx.ethValue.bigintValue)
+                      : undefined,
                 },
               })),
             };
@@ -120,6 +123,7 @@ export function SafeCreateProposalTemplatePage() {
       transactionsDetails={transactions => <TransactionsDetails transactions={transactions} />}
       templateDetails={title => <TemplateDetails title={title} />}
       streamsDetails={null}
+      key={initialProposalTemplate.proposalMetadata.title}
       initialValues={{ ...initialProposalTemplate, nonce: safe?.nextNonce }}
       prepareProposalData={prepareProposalTemplateProposal}
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -120,7 +120,7 @@ export function SafeCreateProposalTemplatePage() {
       transactionsDetails={transactions => <TransactionsDetails transactions={transactions} />}
       templateDetails={title => <TemplateDetails title={title} />}
       streamsDetails={null}
-      initialValues={initialProposalTemplate}
+      initialValues={{ ...initialProposalTemplate, nonce: safe?.nextNonce }}
       prepareProposalData={prepareProposalTemplateProposal}
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
         if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;


### PR DESCRIPTION
### Changes

1. Specify required field `nonce` in `initialValues`. This page was **silently** rely on `ProposalTransactionsForm.tsx` to set `nonce` field previously, but that's removed in https://github.com/decentdao/decent-app/pull/2815 .
2. Use correct bigInt field name so there's no error invoking `BigInt()`.
3. Add key to `ProposalBuilder` so it know when to re-render after potential forked template is fetched. Using `proposalMetadata.title` is enough here to distinguish the different template state, because it's either default one with empty title or forked one with non-empty title.