### PR TITLE
`[ENG-213]` fix: `useAzroiusListeners`unmounts when event fires

### DIFF
--- a/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
@@ -115,7 +115,7 @@ export const useAzoriusListeners = () => {
           // which include the `proposalId` error out because the RPC node (rather, the block it's on)
           // doesn't see this proposal yet (despite the event being caught in the app...).
           const averageBlockTime = await getAverageBlockTime(publicClient);
-          await new Promise(resolve => setTimeout(resolve, averageBlockTime * 1000));
+          await new Promise(resolve => setTimeout(resolve, averageBlockTime * 1000 * 2));
 
           const typedTransactions = log.args.transactions.map(t => ({
             ...t,


### PR DESCRIPTION
Closes [ENG-213](https://linear.app/decent-labs/issue/ENG-213/after-a-proposal-is-created-the-proposal-list-is-not-updated-until-a)

Just doubles the time we wait before we lookup call the `getProposalsVotes` which is causing the failure when ERC20_Votes hasn't been mined yet