### PR TITLE
`[ENG-309]` fix: Throw error causing proposals not to load

### DIFF
--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -251,7 +251,7 @@ export const mapProposalCreatedEventToProposal = async (
       transactionHash = executedEvent?.transactionHash;
     } else {
       // @dev Proposal with 0 transactions goes straight into EXECUTED state, but since executeProposal event wasn't fired - it can't be found
-      throw new Error('Proposal state is EXECUTED, but no execution event found');
+      transactionHash = createdEventTransactionHash;
     }
   } else {
     transactionHash = createdEventTransactionHash;


### PR DESCRIPTION
Closes [ENG-309](https://linear.app/decent-labs/issue/ENG-309/proposal-overview-transaction-details-dont-load-for-dao-targeted#comment-9ef39810)

