### PR TITLE
Bump `fractal-contracts` to 1.6.0-rc.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@fontsource/space-mono": "^5.0.19",
-        "@fractal-framework/fractal-contracts": "^1.6.0-rc.4",
+        "@fractal-framework/fractal-contracts": "^1.6.0-rc.5",
         "@hatsprotocol/modules-sdk": "^1.4.0",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
@@ -5675,9 +5675,9 @@
       "integrity": "sha512-gz9yaKtXCY+HutNvQ4APc15xwZ1f6pWXve5N55x5m/hOoGqgB9Auf3l7CitHNhNJkSKEmaM45M29b0rFeudXlg=="
     },
     "node_modules/@fractal-framework/fractal-contracts": {
-      "version": "1.6.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.6.0-rc.4.tgz",
-      "integrity": "sha512-s2IupEb9e4jByTOJTW3bPaEam9IvFzrbg2wGzZwan9j7O1Tp9qGHM8FkJ0yCL9ouu6Xp3z/LAsSWw05kyshHHQ==",
+      "version": "1.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.6.0-rc.5.tgz",
+      "integrity": "sha512-AO8DG3t8kv4w6I0FGovpoARVgcvatjIdgydsPluXjFRNQ0q64ipig4uYGo8fIf6hZMQ7XlRARDVoOKBSHYrwfw==",
       "license": "MIT",
       "dependencies": {
         "@account-abstraction/contracts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@fontsource/space-mono": "^5.0.19",
-    "@fractal-framework/fractal-contracts": "^1.6.0-rc.4",
+    "@fractal-framework/fractal-contracts": "^1.6.0-rc.5",
     "@hatsprotocol/modules-sdk": "^1.4.0",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -85,6 +85,7 @@ export const optimismConfig: NetworkConfig = {
     freezeVotingMultisigMasterCopy: getAddress(a.MultisigFreezeVoting),
 
     votesErc20MasterCopy: getAddress(a.VotesERC20),
+    votesErc20LockableMasterCopy: getAddress(a.VotesERC20LockableV1),
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -85,6 +85,7 @@ export const polygonConfig: NetworkConfig = {
     freezeVotingMultisigMasterCopy: getAddress(a.MultisigFreezeVoting),
 
     votesErc20MasterCopy: getAddress(a.VotesERC20),
+    votesErc20LockableMasterCopy: getAddress(a.VotesERC20LockableV1),
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 


### PR DESCRIPTION
- Update `@fractal-framework/fractal-contracts` to version `1.6.0-rc.5`
  - `v1.6.0-rc.5` includes the official `VotesERC20LockableV1` contract deployments for all networks, which were forward-ported from the `1.5.0` release.
- Add `votesErc20LockableMasterCopy` to optimism and polygon network configurations.

