### PR TITLE
`[ENG-375]` add asset drop down menu in place of streamed token address

### DIFF
--- a/src/components/ProposalBuilder/ProposalStream.tsx
+++ b/src/components/ProposalBuilder/ProposalStream.tsx
@@ -55,7 +55,7 @@ export function ProposalStream({
 
   const safeAddress = safe?.address;
   const fungibleNonNativeAssetsWithBalance = assetsFungible.filter(
-    asset => !asset.nativeToken && parseFloat(asset.balance) > 0,
+    asset => !asset.possibleSpam && !asset.nativeToken && parseFloat(asset.balance) > 0,
   );
   const selectedAssetIndex = fungibleNonNativeAssetsWithBalance.findIndex(
     asset => asset.tokenAddress === stream.tokenAddress,

--- a/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
@@ -125,7 +125,7 @@ export function SafeSablierProposalCreatePage() {
   }
 
   const fungibleNonNativeAssetsWithBalance = assetsFungible.filter(
-    asset => !asset.nativeToken && parseFloat(asset.balance) > 0,
+    asset => !asset.possibleSpam && !asset.nativeToken && parseFloat(asset.balance) > 0,
   );
   if (!fungibleNonNativeAssetsWithBalance.length) {
     return (


### PR DESCRIPTION
### Summary

* Use asset dropdown menu instead of contract address input
* Display a toast when there's no available asset to stream
* Assets filter by `!asset.possibleSpam && !asset.nativeToken && parseFloat(asset.balance) > 0`.

### Screenshots
#### Asset dropdown
<img width="656" alt="image" src="https://github.com/user-attachments/assets/611e59ac-7b3d-49e2-8f28-065a2bcb4345" />

#### No available asset
<img width="656" alt="image" src="https://github.com/user-attachments/assets/0d326389-b2f0-49ab-ba14-cc94728135fc" />
