### PR TITLE
Remove `maxFeePerGas`; get `maxPriorityFeePerGas` directly from Alchemy

### DIFF
--- a/src/hooks/DAO/proposal/useCastVote.ts
+++ b/src/hooks/DAO/proposal/useCastVote.ts
@@ -10,6 +10,7 @@ import { EntryPoint07Abi } from '../../../assets/abi/EntryPoint07Abi';
 import { useStore } from '../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
+import { fetchMaxPriorityFeePerGas } from '../../../utils/gaslessVoting';
 import useNetworkPublicClient from '../../useNetworkPublicClient';
 import { useNetworkWalletClient } from '../../useNetworkWalletClient';
 import { useTransaction } from '../../utils/useTransaction';
@@ -167,25 +168,10 @@ const useCastVote = (proposalId: string, strategy: Address) => {
       return;
     }
 
-    const {
-      maxFeePerGas: maxFeePerGasEstimate,
-      maxPriorityFeePerGas: maxPriorityFeePerGasEstimate,
-    } = await publicClient.estimateFeesPerGas();
-    const castVoteCallData = prepareCastVoteData(0);
-
     const networkConfig = getConfigByChainId(publicClient.chain.id);
     if (!networkConfig.maxPriorityFeePerGasMultiplier) {
       return;
     }
-
-    // `maxPriorityFeePerGas` returned from `estimateFeesPerGas` needs to be multiplied by this value to match minimum requirement here https://docs.alchemy.com/reference/rundler-maxpriorityfeepergas
-    const maxPriorityFeePerGasMultiplier = networkConfig.maxPriorityFeePerGasMultiplier;
-
-    // Adds buffer to maxFeePerGasEstimate to ensure transaction gets included
-    const maxFeePerGasMultiplier = 50n;
-
-    const maxPriorityFeePerGas = maxPriorityFeePerGasEstimate * maxPriorityFeePerGasMultiplier;
-    const maxFeePerGas = maxFeePerGasEstimate * maxFeePerGasMultiplier;
 
     const smartWallet = await toLightSmartAccount({
       client: publicClient,
@@ -198,12 +184,14 @@ const useCastVote = (proposalId: string, strategy: Address) => {
       transport: http(rpcEndpoint),
     });
 
+    const maxPriorityFeePerGas = await fetchMaxPriorityFeePerGas(networkConfig);
+
     const userOpWithoutCallData = {
       paymaster: paymasterAddress,
       maxPriorityFeePerGas,
-      maxFeePerGas,
     };
 
+    const callDataForEstimation = prepareCastVoteData(0);
     const {
       preVerificationGas,
       verificationGasLimit,
@@ -212,28 +200,23 @@ const useCastVote = (proposalId: string, strategy: Address) => {
       paymasterPostOpGasLimit,
     } = await bundlerClient.estimateUserOperationGas({
       ...userOpWithoutCallData,
-      calls: [castVoteCallData],
+      calls: [callDataForEstimation],
     });
 
     // Calculate gas
     // check algorithm at https://github.com/alchemyplatform/rundler/blob/fae8909b34e5874c0cae2d06aa841a8a112d22a0/crates/types/src/user_operation/v0_7.rs#L206-L215
+    const { maxFeePerGas: maxFeePerGasEstimate } = await publicClient.estimateFeesPerGas();
     const gasUsed =
       preVerificationGas +
       verificationGasLimit +
       callGasLimit +
       (paymasterVerificationGasLimit ?? 0n) +
       (paymasterPostOpGasLimit ?? 0n);
-    const gasCost = maxFeePerGas * gasUsed;
-
-    const userOp = {
-      ...userOpWithoutCallData,
-      maxPriorityFeePerGas: (maxPriorityFeePerGasEstimate * 13n) / 10n,
-      maxFeePerGas: (maxFeePerGasEstimate * 13n) / 10n,
-    };
+    const gasCost = maxFeePerGasEstimate * gasUsed;
 
     return {
       gasCost,
-      userOp,
+      userOpWithoutCallData,
       bundlerClient,
     };
   }, [
@@ -304,13 +287,13 @@ const useCastVote = (proposalId: string, strategy: Address) => {
         if (!gaslessVoteData) {
           return;
         }
-        const { userOp, bundlerClient } = gaslessVoteData;
+        const { userOpWithoutCallData, bundlerClient } = gaslessVoteData;
 
         const castVoteCallData = prepareCastVoteData(selectedVoteChoice);
 
         // Sign and send UserOperation to bundler
         const hash = await bundlerClient.sendUserOperation({
-          ...userOp,
+          ...userOpWithoutCallData,
           calls: [castVoteCallData],
         });
 

--- a/src/utils/gaslessVoting.ts
+++ b/src/utils/gaslessVoting.ts
@@ -7,6 +7,7 @@ import {
   encodePacked,
   getAbiItem,
   getCreate2Address,
+  Hex,
   keccak256,
   parseAbiParameters,
   stringToHex,
@@ -14,6 +15,7 @@ import {
 } from 'viem';
 import { generateContractByteCodeLinear } from '../models/helpers/utils';
 import { FractalTokenType, GovernanceType } from '../types';
+import { NetworkConfig } from '../types/network';
 
 export const getPaymasterSaltNonce = (safeAddress: Address, chainId: number) => {
   const salt = `${safeAddress}-${chainId}`;
@@ -102,4 +104,32 @@ export const getVoteSelectorAndValidator = (
 
   const voteSelector = toFunctionSelector(voteAbiItem);
   return { voteSelector, voteValidator };
+};
+
+export const fetchMaxPriorityFeePerGas = async (networkConfig: NetworkConfig) => {
+  // Fetch minimum maxPriorityFeePerGasMultiplier from Alchemy
+  try {
+    const response = await fetch(networkConfig.rpcEndpoint, {
+      method: 'POST',
+      body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'rundler_maxPriorityFeePerGas' }),
+    });
+
+    if (!response.ok) {
+      console.error('Error fetching maxPriorityFeePerGas from Alchemy:', {
+        status: response.status,
+        statusText: response.statusText,
+        chain: networkConfig.chain.name,
+      });
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return BigInt(data.result as Hex);
+  } catch (error) {
+    console.error('Error fetching maxPriorityFeePerGas from Alchemy:', {
+      chain: networkConfig.chain.name,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
+  }
 };


### PR DESCRIPTION
- `maxPriorityGasFee` is now fetched directly from Alchemy's API. Using that without any modifiers
- Removed `maxFeePerGas`. According to [this doc](https://docs.alchemy.com/docs/maxpriorityfeepergas-vs-maxfeepergas#when-to-use-maxpriorityfeepergas-vs-maxfeepergas-a-hrefwhen-to-use-max-priority-fee-per-gas-vs-max-fee-per-gas-idwhen-to-use-max-priority-fee-per-gas-vs-max-fee-per-gasa:~:text=maxFeePerGas%20%3D%20baseFeePerGas%20%2B%20maxPriorityFeePerGas-,When%20to%20use%20maxPriorityFeePerGas%20vs.%20maxFeePerGas%3F,-The%20most%20guaranteed), doing this lets Alchemy tune that based on recent blocks. This works out better that playing whack-a-mole with stupid multipliers.
