### PR TITLE
`[ENG-203]` conditionally render permissions link based on governance type

### DIFF
--- a/src/components/SafeSettings/SettingsNavigation.tsx
+++ b/src/components/SafeSettings/SettingsNavigation.tsx
@@ -135,14 +135,16 @@ export default function SettingsNavigation() {
           >
             <Text color="neutral-7">{(modules ?? []).length + (safe?.guard ? 1 : 0)}</Text>
           </SettingsLink>
-          <SettingsLink
-            path={DAO_ROUTES.settingsPermissions.relative(addressPrefix, safe.address)}
-            leftIcon={<CheckSquare fontSize="1.5rem" />}
-            title={t('permissionsTitle')}
-            showDivider={false}
-          >
-            <Text color="neutral-7">{azoriusGovernance.votingStrategy ? 1 : 0}</Text>
-          </SettingsLink>
+          {governance.isAzorius && (
+            <SettingsLink
+              path={DAO_ROUTES.settingsPermissions.relative(addressPrefix, safe.address)}
+              leftIcon={<CheckSquare fontSize="1.5rem" />}
+              title={t('permissionsTitle')}
+              showDivider={false}
+            >
+              <Text color="neutral-7">{azoriusGovernance.votingStrategy ? 1 : 0}</Text>
+            </SettingsLink>
+          )}
         </>
       )}
     </Flex>


### PR DESCRIPTION
- SettingsNavigation.tsx: wrap SettingsLink in a conditional check for Azorius governance

## Screenshot
![localhost_3000_settings_general_dao=sep_0x108951B78da9da2C9ED7Bc76E0Af73C0A67Db545(Desktop)](https://github.com/user-attachments/assets/5ca9ad02-e265-4c88-9cc4-8626aee77550)
