### PR TITLE
`[ENG-680]` Remove Actions bugfix 

### DIFF
--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -14,6 +14,7 @@ import { useCanUserCreateProposal } from '../../hooks/utils/useCanUserSubmitProp
 import { ActionsExperience } from '../../pages/dao/proposals/actions/new/ActionsExperience';
 import { useStore } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
+import { useProposalActionsStore } from '../../store/actions/useProposalActionsStore';
 import { useDaoInfoStore } from '../../store/daoInfo/useDaoInfoStore';
 import { BigIntValuePair, CreateProposalSteps, ProposalExecuteData } from '../../types';
 import {
@@ -114,6 +115,7 @@ export function ProposalBuilder({
   const { safe } = useDaoInfoStore();
   const safeAddress = safe?.address;
 
+  const { resetActions } = useProposalActionsStore();
   const { addressPrefix } = useNetworkConfigStore();
   const { submitProposal, pendingCreateTx } = useSubmitProposal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
@@ -121,6 +123,7 @@ export function ProposalBuilder({
 
   const successCallback = () => {
     if (safeAddress) {
+      resetActions();
       // Redirecting to home page so that user will see newly created Proposal
       navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress));
     }
@@ -129,6 +132,7 @@ export function ProposalBuilder({
   return (
     <Formik<CreateProposalForm>
       validationSchema={createProposalValidation}
+      enableReinitialize
       initialValues={initialValues}
       onSubmit={async values => {
         if (!canUserCreateProposal) {
@@ -234,15 +238,7 @@ export function ProposalBuilder({
                         <>{mainContent(formikProps, pendingCreateTx, nonce, currentStep)}</>
                       )}
                     </Box>
-                    {showActionsExperience ? (
-                      <ActionsExperience
-                        onRemove={(index: number) => {
-                          const newActions = [...formikProps.values.transactions];
-                          newActions.splice(index, 1);
-                          formikProps.setFieldValue('transactions', newActions);
-                        }}
-                      />
-                    ) : null}
+                    {showActionsExperience ? <ActionsExperience /> : null}
                     <StepButtons
                       renderButtons={renderButtons}
                       currentStep={currentStep}

--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -1,12 +1,11 @@
 import { Button, Flex, Grid, Icon, Text, useDisclosure } from '@chakra-ui/react';
 import { ArrowsDownUp, Plus, PlusCircle, SquaresFour } from '@phosphor-icons/react';
-import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DETAILS_BOX_SHADOW } from '../../../constants/common';
 import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useStore } from '../../../providers/App/AppProvider';
 import { useProposalActionsStore } from '../../../store/actions/useProposalActionsStore';
-import { CreateProposalForm, ProposalActionType } from '../../../types';
+import { ProposalActionType } from '../../../types';
 import { prepareSendAssetsActionData } from '../../../utils/dao/prepareSendAssetsActionData';
 import { ModalBase } from './ModalBase';
 import { ModalType } from './ModalProvider';
@@ -78,13 +77,12 @@ export function AddActions() {
 
   const { t } = useTranslation(['actions', 'modals']);
   const { addAction } = useProposalActionsStore();
-  const { values, setFieldValue } = useFormikContext<CreateProposalForm>();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsData => {
       const { action } = prepareSendAssetsActionData(sendAssetsData);
-      setFieldValue('transactions', [...values.transactions, ...action.transactions]);
+
       addAction({ ...action, content: <></> });
     },
     submitButtonText: t('Add Action', { ns: 'modals' }),
@@ -92,9 +90,10 @@ export function AddActions() {
 
   const openTransactionBuilderModal = useDecentModal(ModalType.TRANSACTION_BUILDER, {
     onSubmit: transactionBuilderData => {
-      setFieldValue('transactions', [...values.transactions, ...transactionBuilderData]);
+      const actionType = ProposalActionType.TRANSACTION_BUILDER;
+
       addAction({
-        actionType: ProposalActionType.TRANSACTION_BUILDER,
+        actionType: actionType,
         content: <></>,
         transactions: transactionBuilderData,
       });

--- a/src/pages/dao/proposals/actions/new/ActionsExperience.tsx
+++ b/src/pages/dao/proposals/actions/new/ActionsExperience.tsx
@@ -4,7 +4,7 @@ import { ProposalActionCard } from '../../../../../components/ProposalBuilder/Pr
 import { AddActions } from '../../../../../components/ui/modals/AddActions';
 import { useProposalActionsStore } from '../../../../../store/actions/useProposalActionsStore';
 
-export function ActionsExperience({ onRemove }: { onRemove?: (index: number) => void }) {
+export function ActionsExperience() {
   const { t } = useTranslation('actions');
   const { actions } = useProposalActionsStore();
   const { removeAction } = useProposalActionsStore();
@@ -32,7 +32,6 @@ export function ActionsExperience({ onRemove }: { onRemove?: (index: number) => 
               action={action}
               removeAction={() => {
                 removeAction(index);
-                onRemove?.(index);
               }}
               index={index}
             />


### PR DESCRIPTION
## Description
I realized that the way I originally set this up was causing more problems than it solved and moving the `ActionsExperience` actually had fixed the dupe issue we had saw with the `reEnableInitialization` on the Formik form. After some trial and error with trying a more direct approach, and some testing I think its safe from dupes and we don't need to manually groom the transactions. 

@johnqh This needs to make it in next release with the other work to ensure no this feature goes out working correctly and allowing users to remove created transactions without refresh. 