### PR TITLE
Eng 687 cleanup

### DIFF
--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -61,6 +61,17 @@ export interface ICreationStepProps extends Omit<FormikProps<CreatorFormState>, 
   steps: CreatorSteps[];
 }
 
+type DAOGovernorERC20Token<T = bigint> = {
+  tokenCreationType: TokenCreationType;
+  tokenImportAddress?: Address;
+  tokenName: string;
+  tokenSymbol: string;
+  locked: TokenLockType;
+  tokenSupply: T;
+  tokenAllocations: { amount: T; address: string }[];
+  parentAllocationAmount: T;
+};
+
 export interface CreatorFormState<T = BigIntValuePair> {
   essentials: DAOEssentials;
   multisig: SafeConfiguration;
@@ -75,17 +86,6 @@ export type DAOEssentials = {
   governance: GovernanceType;
   snapshotENS: string;
   gaslessVoting: boolean;
-};
-
-export type DAOGovernorERC20Token<T = bigint> = {
-  tokenCreationType: TokenCreationType;
-  tokenImportAddress?: Address;
-  tokenName: string;
-  tokenSymbol: string;
-  locked: TokenLockType;
-  tokenSupply: T;
-  tokenAllocations: { amount: T; address: string }[];
-  parentAllocationAmount: T;
 };
 
 export type ERC721TokenConfig<T = bigint> = {
@@ -115,7 +115,7 @@ export type DAOFreezeGuardConfig<T = bigint> = {
   attachFractalModule: boolean;
 };
 
-export interface SafeConfiguration {
+interface SafeConfiguration {
   trustedAddresses: string[];
   signatureThreshold: number;
   numOfSigners?: number;
@@ -149,22 +149,19 @@ export type DAOTrigger = (
   customNonce?: number,
 ) => void;
 
-export type AddressValidationMap = Map<string, AddressValidation>;
-
-export type AddressValidation = {
-  address: string;
-  isValidAddress: boolean;
-};
+export type AddressValidationMap = Map<
+  string,
+  {
+    address: string;
+    isValidAddress: boolean;
+  }
+>;
 
 export type TokenAllocation<T = bigint> = {
   amount: T;
   address: Address;
 };
 
-export type CreateDAOFunc = (
-  daoData: SafeMultisigDAO,
-  successCallback: DeployDAOSuccessCallback,
-) => void;
 export type DeployDAOSuccessCallback = (address: string) => void;
 export type DAODetails = {
   daoName: string;


### PR DESCRIPTION
Minor types cleanup -- removed unneeded exports and an unused type. Stuff I happened to notice while working on ENG-687.