### PR TITLE
chore(types): Enforce consistency for Account Abstraction config

### DIFF
--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -117,6 +117,7 @@ export const baseConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
+  accountAbstractionSupported: false,
 };
 
 export default baseConfig;

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -138,6 +138,7 @@ export const mainnetConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
+  accountAbstractionSupported: true,
   bundlerMinimumStake: 100_000_000_000_000_000n, // 0.1 ETH
 };
 

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -117,6 +117,7 @@ export const optimismConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
+  accountAbstractionSupported: false,
 };
 
 export default optimismConfig;

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -117,6 +117,7 @@ export const polygonConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
+  accountAbstractionSupported: false,
 };
 
 export default polygonConfig;

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -132,6 +132,7 @@ export const sepoliaConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
+  accountAbstractionSupported: true,
   bundlerMinimumStake: 10_000_000_000_000_000n, // 0.01 ETH
 };
 

--- a/src/providers/NetworkConfig/useNetworkConfigStore.ts
+++ b/src/providers/NetworkConfig/useNetworkConfigStore.ts
@@ -3,10 +3,10 @@ import { NetworkConfig } from '../../types/network';
 import { networks } from './networks';
 import { mainnetConfig } from './networks/mainnet';
 
-interface NetworkConfigStore extends NetworkConfig {
+type NetworkConfigStore = NetworkConfig & {
   getConfigByChainId: (chainId?: number) => NetworkConfig;
   setCurrentConfig: (config: NetworkConfig) => void;
-}
+};
 
 export const supportedNetworks = Object.values(networks).sort((a, b) => a.order - b.order);
 export const supportedEnsNetworks = Object.values(networks)

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -93,10 +93,12 @@ type NetworkConfigBase = {
     };
   };
   createOptions: GovernanceType[];
+  accountAbstractionSupported: boolean;
 };
 
 // Type for networks *with* Account Abstraction
 type NetworkConfigWithAA = NetworkConfigBase & {
+  accountAbstractionSupported: true;
   contracts: ContractsBase & {
     // accountAbstraction is REQUIRED here
     accountAbstraction: {
@@ -110,6 +112,7 @@ type NetworkConfigWithAA = NetworkConfigBase & {
 
 // Type for networks *without* Account Abstraction
 type NetworkConfigWithoutAA = NetworkConfigBase & {
+  accountAbstractionSupported: false;
   contracts: ContractsBase & {
     // accountAbstraction is OPTIONAL and UNDEFINED here
     accountAbstraction?: undefined;

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -9,8 +9,68 @@ export type TheGraphConfig = {
 
 export type NetworkPrefix = 'base' | 'eth' | 'oeth' | 'matic' | 'sep'; // copy whatever Safe uses
 
-export type NetworkConfig = {
-  order: number; // any arbitrary integer, used to "order" the networks in the dropdown
+type ContractsBase = {
+  gnosisSafeL2Singleton: Address;
+  gnosisSafeProxyFactory: Address;
+  compatibilityFallbackHandler: Address;
+
+  multiSendCallOnly: Address;
+
+  zodiacModuleProxyFactory: Address;
+
+  linearVotingErc20MasterCopy: Address;
+  linearVotingErc20HatsWhitelistingMasterCopy: Address;
+  linearVotingErc721MasterCopy: Address;
+  linearVotingErc721HatsWhitelistingMasterCopy: Address;
+
+  linearVotingErc20V1MasterCopy: Address;
+  linearVotingErc20HatsWhitelistingV1MasterCopy: Address;
+  linearVotingErc721V1MasterCopy: Address;
+  linearVotingErc721HatsWhitelistingV1MasterCopy: Address;
+
+  moduleAzoriusMasterCopy: Address;
+  moduleFractalMasterCopy: Address;
+
+  freezeGuardAzoriusMasterCopy: Address;
+  freezeGuardMultisigMasterCopy: Address;
+
+  freezeVotingErc20MasterCopy: Address;
+  freezeVotingErc721MasterCopy: Address;
+  freezeVotingMultisigMasterCopy: Address;
+
+  votesErc20MasterCopy: Address;
+  votesErc20LockableMasterCopy?: Address;
+
+  claimErc20MasterCopy: Address;
+
+  decentAutonomousAdminV1MasterCopy: Address;
+
+  paymaster?: {
+    decentPaymasterV1MasterCopy: Address;
+    linearERC20VotingV1ValidatorV1: Address;
+    linearERC721VotingV1ValidatorV1: Address;
+  };
+
+  keyValuePairs: Address;
+
+  decentHatsCreationModule: Address;
+  decentHatsModificationModule: Address;
+  decentSablierStreamManagementModule: Address;
+
+  hatsProtocol: Address;
+  erc6551Registry: Address;
+  hatsAccount1ofNMasterCopy: Address;
+  hatsElectionsEligibilityMasterCopy: Address;
+  sablierV2Batch: Address;
+  sablierV2LockupDynamic: Address;
+  sablierV2LockupTranched: Address;
+  sablierV2LockupLinear: Address;
+  disperse: Address;
+};
+
+// Base type containing properties common to all network configs
+type NetworkConfigBase = {
+  order: number;
   chain: Chain;
   rpcEndpoint: string;
   safeBaseURL: string;
@@ -25,70 +85,6 @@ export type NetworkConfig = {
     chainSupported: boolean;
     deFiSupported: boolean;
   };
-  contracts: {
-    gnosisSafeL2Singleton: Address;
-    gnosisSafeProxyFactory: Address;
-    compatibilityFallbackHandler: Address;
-
-    multiSendCallOnly: Address;
-
-    zodiacModuleProxyFactory: Address;
-
-    linearVotingErc20MasterCopy: Address;
-    linearVotingErc20HatsWhitelistingMasterCopy: Address;
-    linearVotingErc721MasterCopy: Address;
-    linearVotingErc721HatsWhitelistingMasterCopy: Address;
-
-    linearVotingErc20V1MasterCopy: Address;
-    linearVotingErc20HatsWhitelistingV1MasterCopy: Address;
-    linearVotingErc721V1MasterCopy: Address;
-    linearVotingErc721HatsWhitelistingV1MasterCopy: Address;
-
-    moduleAzoriusMasterCopy: Address;
-    moduleFractalMasterCopy: Address;
-
-    freezeGuardAzoriusMasterCopy: Address;
-    freezeGuardMultisigMasterCopy: Address;
-
-    freezeVotingErc20MasterCopy: Address;
-    freezeVotingErc721MasterCopy: Address;
-    freezeVotingMultisigMasterCopy: Address;
-
-    votesErc20MasterCopy: Address;
-    votesErc20LockableMasterCopy?: Address;
-
-    claimErc20MasterCopy: Address;
-
-    decentAutonomousAdminV1MasterCopy: Address;
-
-    paymaster?: {
-      decentPaymasterV1MasterCopy: Address;
-      linearERC20VotingV1ValidatorV1: Address;
-      linearERC721VotingV1ValidatorV1: Address;
-    };
-
-    keyValuePairs: Address;
-
-    decentHatsCreationModule: Address;
-    decentHatsModificationModule: Address;
-    decentSablierStreamManagementModule: Address;
-
-    hatsProtocol: Address;
-    erc6551Registry: Address;
-    hatsAccount1ofNMasterCopy: Address;
-    hatsElectionsEligibilityMasterCopy: Address;
-    sablierV2Batch: Address;
-    sablierV2LockupDynamic: Address;
-    sablierV2LockupTranched: Address;
-    sablierV2LockupLinear: Address;
-    disperse: Address;
-
-    // only set on networks for which we support account abstraction functionality
-    accountAbstraction?: {
-      entryPointv07: Address;
-      lightAccountFactory: Address;
-    };
-  };
   staking: {
     lido?: {
       stETHContractAddress: Address;
@@ -97,5 +93,30 @@ export type NetworkConfig = {
     };
   };
   createOptions: GovernanceType[];
-  bundlerMinimumStake?: bigint;
 };
+
+// Type for networks *with* Account Abstraction
+type NetworkConfigWithAA = NetworkConfigBase & {
+  contracts: ContractsBase & {
+    // accountAbstraction is REQUIRED here
+    accountAbstraction: {
+      entryPointv07: Address;
+      lightAccountFactory: Address;
+    };
+  };
+  // bundlerMinimumStake is REQUIRED here
+  bundlerMinimumStake: bigint;
+};
+
+// Type for networks *without* Account Abstraction
+type NetworkConfigWithoutAA = NetworkConfigBase & {
+  contracts: ContractsBase & {
+    // accountAbstraction is OPTIONAL and UNDEFINED here
+    accountAbstraction?: undefined;
+  };
+  // bundlerMinimumStake is OPTIONAL and UNDEFINED here
+  bundlerMinimumStake?: undefined;
+};
+
+// The final NetworkConfig is a union of the two possibilities
+export type NetworkConfig = NetworkConfigWithAA | NetworkConfigWithoutAA;


### PR DESCRIPTION
Closes [ENG-689](https://linear.app/decent-labs/issue/ENG-689/add-stronger-type-safety-between-account-abstraction-contracts-and)

## PR Description

This PR introduces explicit configuration for Account Abstraction (AA) support on a per-network basis and refactors the `NetworkConfig` type for improved type safety.

### Changes

1.  **Added `accountAbstractionSupported` Flag:**
    *   A new boolean flag, `accountAbstractionSupported`, has been added to the `NetworkConfig` type (`src/types/network.ts`).
    *   Each network configuration file (`src/providers/NetworkConfig/networks/*.ts`) has been updated to include this flag, specifying whether AA is supported on that network (e.g., `true` for Mainnet and Sepolia, `false` for Base, Optimism, Polygon).

2.  **Refactored `NetworkConfig` Type:**
    *   The `NetworkConfig` type in `src/types/network.ts` has been refactored into a discriminated union based on the `accountAbstractionSupported` flag.
    *   **If `accountAbstractionSupported` is `true`:** The type requires the `contracts.accountAbstraction` object and the `bundlerMinimumStake` property to be defined.
    *   **If `accountAbstractionSupported` is `false`:** The type ensures that `contracts.accountAbstraction` and `bundlerMinimumStake` are undefined.

### Benefits

*   **Improved Type Safety:** Makes it explicit at the type level which networks support AA features, preventing potential runtime errors when accessing AA-specific properties like `contracts.accountAbstraction` or `bundlerMinimumStake` on unsupported networks.
*   **Clearer Configuration:** Provides a clear and explicit way to enable or disable AA features for each network.

This change ensures that components relying on AA features can safely access the necessary configuration details only when supported by the current network.