### PR TITLE
feat(gasless): Remove flag_gasless_staking feature flag

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -12,11 +12,9 @@ import { WarningCircle } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useFeatureFlag from '../../../helpers/environmentFeatureFlags';
-import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
 import { FractalModuleType, ICreationStepProps, VotingStrategyType } from '../../../types';
 import { DEV_VOTING_PERIOD_MINUTES } from '../../../utils/dev/devModeConstants';
-import { GaslessVotingToggleDAOCreate } from '../../GaslessVoting/GaslessVotingToggle';
 import { BigIntInput } from '../../ui/forms/BigIntInput';
 import { CustomNonceInput } from '../../ui/forms/CustomNonceInput';
 import { LabelComponent } from '../../ui/forms/InputComponent';
@@ -56,10 +54,6 @@ export function AzoriusGovernance(props: ICreationStepProps) {
   const { values, setFieldValue, isSubmitting, transactionPending, isSubDAO, mode } = props;
 
   const { safe, subgraphInfo, modules } = useDaoInfoStore();
-  const {
-    contracts: { accountAbstraction },
-  } = useNetworkConfigStore();
-  const gaslessVotingSupported = accountAbstraction !== undefined;
 
   const fractalModule = useMemo(() => {
     if (!modules) return null;
@@ -262,14 +256,6 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             renderTrimmed={false}
           />
         </Box>
-      )}
-      {gaslessVotingSupported && (
-        <GaslessVotingToggleDAOCreate
-          isEnabled={values.essentials.gaslessVoting}
-          onToggle={() =>
-            setFieldValue('essentials.gaslessVoting', !values.essentials.gaslessVoting)
-          }
-        />
       )}
       <StepButtons
         {...props}

--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -59,7 +59,6 @@ export function AzoriusGovernance(props: ICreationStepProps) {
   const {
     contracts: { accountAbstraction },
   } = useNetworkConfigStore();
-  const gaslessStakingFeatureEnabled = useFeatureFlag('flag_gasless_staking');
   const gaslessVotingSupported = accountAbstraction !== undefined;
 
   const fractalModule = useMemo(() => {
@@ -264,7 +263,7 @@ export function AzoriusGovernance(props: ICreationStepProps) {
           />
         </Box>
       )}
-      {gaslessVotingSupported && !gaslessStakingFeatureEnabled && (
+      {gaslessVotingSupported && (
         <GaslessVotingToggleDAOCreate
           isEnabled={values.essentials.gaslessVoting}
           onToggle={() =>

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -207,9 +207,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
   });
 
   const gaslessFeatureEnabled = useFeatureFlag('flag_gasless_voting');
-  const gaslessStakingFeatureEnabled = useFeatureFlag('flag_gasless_staking');
-  const gaslessStakingEnabled =
-    gaslessVotingEnabled && gaslessStakingFeatureEnabled && bundlerMinimumStake !== undefined;
+  const gaslessStakingEnabled = gaslessVotingEnabled && bundlerMinimumStake !== undefined;
   if (!gaslessFeatureEnabled) return null;
 
   const paymasterBalance = depositInfo?.balance || 0n;

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getContract } from 'viem';
 import { EntryPoint07Abi } from '../../assets/abi/EntryPoint07Abi';
-import { DETAILS_BOX_SHADOW } from '../../constants/common';
 import { DAO_ROUTES } from '../../constants/routes';
 import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { useDepositInfo } from '../../hooks/DAO/accountAbstraction/useDepositInfo';
@@ -19,7 +18,6 @@ import { RefillGasData } from '../ui/modals/GaslessVoting/RefillGasTankModal';
 import { ModalType } from '../ui/modals/ModalProvider';
 import { useDecentModal } from '../ui/modals/useDecentModal';
 import Divider from '../ui/utils/Divider';
-import { StarterPromoBanner } from './StarterPromoBanner';
 
 interface GaslessVotingToggleProps {
   isEnabled: boolean;
@@ -92,44 +90,6 @@ function GaslessVotingToggleContent({
         />
       </HStack>
     </Box>
-  );
-}
-
-export function GaslessVotingToggleDAOCreate(props: GaslessVotingToggleProps) {
-  const gaslessFeatureEnabled = useFeatureFlag('flag_gasless_voting');
-  if (!gaslessFeatureEnabled) return null;
-
-  return (
-    <Flex
-      direction="column"
-      gap="0.5rem"
-    >
-      <Box
-        borderRadius="0.75rem"
-        bg="neutral-2"
-        p="1.5rem"
-        display="flex"
-        flexDirection="column"
-        gap="1.5rem"
-        boxShadow={DETAILS_BOX_SHADOW}
-        mt={2}
-      >
-        <Box
-          borderRadius="0.5rem"
-          border="1px solid"
-          borderColor="neutral-3"
-          px="1.5rem"
-          py="1rem"
-          display="flex"
-          flexDirection="column"
-          alignItems="flex-start"
-          mt={2}
-        >
-          <GaslessVotingToggleContent {...props} />
-        </Box>
-      </Box>
-      <StarterPromoBanner />
-    </Flex>
   );
 }
 
@@ -245,8 +205,6 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
         isSettings
         displayNeedStakingLabel={gaslessStakingEnabled && stakedAmount < minStakeAmount}
       />
-
-      {!gaslessVotingEnabled && <StarterPromoBanner />}
 
       {gaslessVotingEnabled && (
         <Flex justifyContent="space-between">

--- a/src/helpers/featureFlags.ts
+++ b/src/helpers/featureFlags.ts
@@ -2,7 +2,6 @@ export const FEATURE_FLAGS = [
   'flag_dev',
   'flag_gasless_voting',
   'flag_iframe_template',
-  'flag_gasless_staking',
   'flag_store_v2',
   'flag_locked_token',
 ] as const;

--- a/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
+++ b/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
@@ -12,7 +12,6 @@ import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import NestedPageHeader from '../../../../components/ui/page/Header/NestedPageHeader';
 import Divider from '../../../../components/ui/utils/Divider';
 import { DAO_ROUTES } from '../../../../constants/routes';
-import useFeatureFlag from '../../../../helpers/environmentFeatureFlags';
 import { useDepositInfo } from '../../../../hooks/DAO/accountAbstraction/useDepositInfo';
 import useSubmitProposal from '../../../../hooks/DAO/proposal/useSubmitProposal';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
@@ -63,8 +62,7 @@ export function SafeGeneralSettingsPage() {
     bundlerMinimumStake,
   } = useNetworkConfigStore();
   const { depositInfo } = useDepositInfo(paymasterAddress);
-  const gaslessStakingFeatureEnabled =
-    useFeatureFlag('flag_gasless_staking') && bundlerMinimumStake !== undefined;
+  const gaslessStakingFeatureEnabled = bundlerMinimumStake !== undefined;
 
   const isMultisigGovernance = votingStrategyType === GovernanceType.MULTISIG;
   const gaslessVotingSupported =


### PR DESCRIPTION
Closes [ENG-690](https://linear.app/decent-labs/issue/ENG-690/remove-flag-gasless-staking)

Depends on https://github.com/decentdao/decent-app/pull/2917#pullrequestreview-2778960757

Removes the `flag_gasless_staking` feature flag and associated logic.

The gasless staking functionality is now enabled by default on any network that supports account abstraction (determined by the presence of `bundlerMinimumStake` in the network configuration). This simplifies the configuration and makes the feature consistently available where the underlying infrastructure supports it.