### PR TITLE
fix(i18n): Explicitly specify namespaces for useTranslation

### DIFF
--- a/src/components/Activity/ActivityAddress.tsx
+++ b/src/components/Activity/ActivityAddress.tsx
@@ -14,7 +14,7 @@ export function ActivityAddress({
   addComma?: boolean;
 }) {
   const { displayName } = useGetAccountName(address);
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   return (
     <EtherscanLink
       type="address"

--- a/src/components/Proposals/ProposalVotes/ProposalERC20VoteItem.tsx
+++ b/src/components/Proposals/ProposalVotes/ProposalERC20VoteItem.tsx
@@ -17,7 +17,7 @@ export default function ProposalERC20VoteItem({
   govTokenDecimals: number;
   govTokenSymbol: string;
 }) {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'proposal']);
   const { displayName } = useGetAccountName(vote.voter);
   const user = useAccount();
   return (

--- a/src/components/Proposals/ProposalVotes/ProposalERC20VoteItem.tsx
+++ b/src/components/Proposals/ProposalVotes/ProposalERC20VoteItem.tsx
@@ -17,7 +17,9 @@ export default function ProposalERC20VoteItem({
   govTokenDecimals: number;
   govTokenSymbol: string;
 }) {
-  const { t } = useTranslation(['common', 'proposal']);
+  const { t: tCommon } = useTranslation('common');
+  const { t: tProposal } = useTranslation('proposal');
+
   const { displayName } = useGetAccountName(vote.voter);
   const user = useAccount();
   return (
@@ -25,12 +27,12 @@ export default function ProposalERC20VoteItem({
       <GridItem>
         <Text color="neutral-7">
           {displayName}
-          {user.address === vote.voter && t('isMeSuffix')}
+          {user.address === vote.voter && tCommon('isMeSuffix')}
         </Text>
       </GridItem>
       <GridItem>
         <StatusBox>
-          <Text color="neutral-7">{t(vote.choice.label)}</Text>
+          <Text color="neutral-7">{tProposal(vote.choice.label)}</Text>
         </StatusBox>
       </GridItem>
       <GridItem>

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVoteItem.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVoteItem.tsx
@@ -16,7 +16,7 @@ interface ISnapshotProposalVoteItem {
 }
 
 export default function SnapshotProposalVoteItem({ proposal, vote }: ISnapshotProposalVoteItem) {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   const { displayName } = useGetAccountName(vote.voter);
   const user = useAccount();
 

--- a/src/components/ui/links/EtherscanLink.tsx
+++ b/src/components/ui/links/EtherscanLink.tsx
@@ -21,7 +21,7 @@ export default function EtherscanLink({
   ...rest
 }: EtherscanLinkProps) {
   const { etherscanBaseURL } = useNetworkConfigStore();
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   const containerRef = useRef<HTMLDivElement>(null);
 
   if (!value) {

--- a/src/components/ui/utils/Sort.tsx
+++ b/src/components/ui/utils/Sort.tsx
@@ -16,7 +16,7 @@ function SortMenuItem({
   testId: string;
   onClick: () => void;
 }) {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   return (
     <MenuItem
       borderRadius="0.75rem"
@@ -41,7 +41,7 @@ interface ISort {
 }
 
 export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   return (
     <Menu isLazy>
       <MenuButton

--- a/src/components/ui/utils/TopErrorFallback.tsx
+++ b/src/components/ui/utils/TopErrorFallback.tsx
@@ -5,7 +5,7 @@ import { useHeaderHeight } from '../../../constants/common';
 import { BASE_ROUTES } from '../../../constants/routes';
 
 export function TopErrorFallback() {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   const navigate = useNavigate();
   const HEADER_HEIGHT = useHeaderHeight();
 

--- a/src/helpers/dateTime.ts
+++ b/src/helpers/dateTime.ts
@@ -24,7 +24,7 @@ export function useDateTimeDisplay(referenceDate: Date) {
   const diffInMinutes = Math.abs(differenceInMinutes(referenceDate, now));
   const diffInMonths = Math.abs(differenceInMonths(referenceDate, now));
 
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   if (diffInMinutes < 5) {
     return t(isCountdown ? 'labelNowishLeft' : 'labelNowishAgo');
   } else if (diffInMinutes < 60) {

--- a/src/pages/dao/dapps/SafeProposalDappsPage.tsx
+++ b/src/pages/dao/dapps/SafeProposalDappsPage.tsx
@@ -16,7 +16,7 @@ export function SafeProposalDappsPage() {
     amplitude.track(analyticsEvents.ProposalDappsPageOpened);
   }, []);
 
-  const { t } = useTranslation();
+  const { t } = useTranslation('breadcrumbs');
   const { chain } = useNetworkConfigStore();
   const { safe } = useDaoInfoStore();
   const { dapps } = useSupportedDapps(chain.id);
@@ -27,10 +27,10 @@ export function SafeProposalDappsPage() {
   return (
     <div>
       <PageHeader
-        title={t('proposalDapps', { ns: 'breadcrumbs' })}
+        title={t('proposalDapps')}
         breadcrumbs={[
           {
-            terminus: t('proposalDapps', { ns: 'breadcrumbs' }),
+            terminus: t('proposalDapps'),
             path: '',
           },
         ]}

--- a/src/pages/dao/dapps/details/SafeProposalDappDetailPage.tsx
+++ b/src/pages/dao/dapps/details/SafeProposalDappDetailPage.tsx
@@ -103,7 +103,7 @@ export function SafeProposalDappDetailPage() {
     amplitude.track(analyticsEvents.ProposalDappsPageOpened);
   }, []);
 
-  const { t } = useTranslation();
+  const { t } = useTranslation('breadcrumbs');
   const { chain } = useNetworkConfigStore();
   const { loadABI } = useABI();
   const { safe } = useDaoInfoStore();
@@ -142,7 +142,7 @@ export function SafeProposalDappDetailPage() {
         title={appName}
         breadcrumbs={[
           {
-            terminus: t('proposalDapps', { ns: 'breadcrumbs' }),
+            terminus: t('proposalDapps'),
             path: DAO_ROUTES.proposalDapps.relative(addressPrefix, safeAddress),
           },
           {

--- a/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
+++ b/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
@@ -31,7 +31,11 @@ export function SafeProposalTemplatesPage() {
     amplitude.track(analyticsEvents.ProposalTemplatesPageOpened);
   }, []);
 
-  const { t } = useTranslation(['modals', 'proposalTemplate', 'common']);
+  const { t: tModals } = useTranslation('modals');
+  const { t: tProposalTemplate } = useTranslation('proposalTemplate');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tBreadcrumbs } = useTranslation('breadcrumbs');
+
   const { daoKey } = useCurrentDAOKey();
   const {
     governance: { proposalTemplates },
@@ -101,7 +105,7 @@ export function SafeProposalTemplatesPage() {
 
   const openAirdropModal = useDecentModal(ModalType.AIRDROP, {
     onSubmit: handleAirdropSubmit,
-    submitButtonText: t('submitProposal'),
+    submitButtonText: tModals('submitProposal'),
   });
 
   const EXAMPLE_TEMPLATES = useMemo(() => {
@@ -110,32 +114,33 @@ export function SafeProposalTemplatesPage() {
     return [
       {
         icon: Parachute,
-        title: t('templateAirdropTitle'),
-        description: t('templateAirdropDescription'),
+        title: tProposalTemplate('templateAirdropTitle'),
+        description: tProposalTemplate('templateAirdropDescription'),
         onProposalTemplateClick: openAirdropModal,
       },
       {
         icon: HourglassMedium,
-        title: t('templateSablierTitle'),
-        description: t('templateSablierDescription'),
+        title: tProposalTemplate('templateSablierTitle'),
+        description: tProposalTemplate('templateSablierDescription'),
         onProposalTemplateClick: () => {
           if (hasAvailableAssetsForSablierStream) {
             navigate(DAO_ROUTES.proposalSablierNew.relative(addressPrefix, safeAddress));
           } else {
-            toast.info(t('noAssetsWithBalance', { ns: 'modals' }));
+            toast.info(tModals('noAssetsWithBalance'));
           }
         },
       },
       {
         icon: ArrowsDownUp,
-        title: t('templateTransferTitle'),
-        description: t('templateTransferDescription'),
+        title: tProposalTemplate('templateTransferTitle'),
+        description: tProposalTemplate('templateTransferDescription'),
         onProposalTemplateClick: openSendAssetsModal,
       },
     ];
   }, [
     safeAddress,
-    t,
+    tModals,
+    tProposalTemplate,
     openAirdropModal,
     openSendAssetsModal,
     hasAvailableAssetsForSablierStream,
@@ -146,10 +151,10 @@ export function SafeProposalTemplatesPage() {
   return (
     <div>
       <PageHeader
-        title={t('proposalTemplates', { ns: 'breadcrumbs' })}
+        title={tBreadcrumbs('proposalTemplates')}
         breadcrumbs={[
           {
-            terminus: t('proposalTemplates', { ns: 'breadcrumbs' }),
+            terminus: tBreadcrumbs('proposalTemplates'),
             path: '',
           },
         ]}
@@ -158,7 +163,7 @@ export function SafeProposalTemplatesPage() {
           <Link to={DAO_ROUTES.proposalTemplateNew.relative(addressPrefix, safeAddress)}>
             <Button minW={0}>
               <AddPlus />
-              <Show above="sm">{t('create')}</Show>
+              <Show above="sm">{tCommon('create')}</Show>
             </Button>
           </Link>
         )}
@@ -197,7 +202,7 @@ export function SafeProposalTemplatesPage() {
         color="white-0"
         mb="1rem"
       >
-        {t('defaultTemplates')}
+        {tProposalTemplate('defaultTemplates')}
       </Text>
       <Flex
         flexDirection="row"

--- a/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
+++ b/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
@@ -31,7 +31,7 @@ export function SafeProposalTemplatesPage() {
     amplitude.track(analyticsEvents.ProposalTemplatesPageOpened);
   }, []);
 
-  const { t } = useTranslation();
+  const { t } = useTranslation(['modals', 'proposalTemplate', 'common']);
   const { daoKey } = useCurrentDAOKey();
   const {
     governance: { proposalTemplates },
@@ -101,7 +101,7 @@ export function SafeProposalTemplatesPage() {
 
   const openAirdropModal = useDecentModal(ModalType.AIRDROP, {
     onSubmit: handleAirdropSubmit,
-    submitButtonText: t('submitProposal', { ns: 'modals' }),
+    submitButtonText: t('submitProposal'),
   });
 
   const EXAMPLE_TEMPLATES = useMemo(() => {
@@ -110,14 +110,14 @@ export function SafeProposalTemplatesPage() {
     return [
       {
         icon: Parachute,
-        title: t('templateAirdropTitle', { ns: 'proposalTemplate' }),
-        description: t('templateAirdropDescription', { ns: 'proposalTemplate' }),
+        title: t('templateAirdropTitle'),
+        description: t('templateAirdropDescription'),
         onProposalTemplateClick: openAirdropModal,
       },
       {
         icon: HourglassMedium,
-        title: t('templateSablierTitle', { ns: 'proposalTemplate' }),
-        description: t('templateSablierDescription', { ns: 'proposalTemplate' }),
+        title: t('templateSablierTitle'),
+        description: t('templateSablierDescription'),
         onProposalTemplateClick: () => {
           if (hasAvailableAssetsForSablierStream) {
             navigate(DAO_ROUTES.proposalSablierNew.relative(addressPrefix, safeAddress));
@@ -128,8 +128,8 @@ export function SafeProposalTemplatesPage() {
       },
       {
         icon: ArrowsDownUp,
-        title: t('templateTransferTitle', { ns: 'proposalTemplate' }),
-        description: t('templateTransferDescription', { ns: 'proposalTemplate' }),
+        title: t('templateTransferTitle'),
+        description: t('templateTransferDescription'),
         onProposalTemplateClick: openSendAssetsModal,
       },
     ];
@@ -197,7 +197,7 @@ export function SafeProposalTemplatesPage() {
         color="white-0"
         mb="1rem"
       >
-        {t('defaultTemplates', { ns: 'proposalTemplate' })}
+        {t('defaultTemplates')}
       </Text>
       <Flex
         flexDirection="row"


### PR DESCRIPTION
Fixes [ENG-691](https://linear.app/decent-labs/issue/ENG-691/localization-string-parsing-issues-in-various-places)

Updates various components and helpers to explicitly provide the relevant namespace(s) when calling the `useTranslation` hook from `react-i18next`.

Previously, some calls relied on the default namespace. Specifying namespaces improves clarity, helps with managing translations, and potentially enables better code splitting or loading strategies for translation files.

I asked the AI to help identify which "pages" are affected by these changes, and this is what it gave me, which looks more or less accurate:

> In summary, the pages most likely affected are:
> - DAO Proposal Dapps Page
> - DAO Proposal Dapp Detail Page
> - DAO Proposal Templates Page
> - DAO Activity/Transactions Page
> - DAO Proposal List Page
> - DAO Proposal Detail Page (both Azorius and Snapshot variants)
> - Pages with sortable lists (like Treasury/Assets, Members if they exist and use this component)
> - Potentially parts of the DAO Dashboard or Settings if they use components like EtherscanLink or ActivityAddress.
> - Technically all pages are affected by the TopErrorFallback change, but only during error states.