### PR TITLE
`[ENG-695]` feat: Remove gasless voting setup from initial DAO deployment

### DIFF
--- a/src/components/DaoCreator/constants.ts
+++ b/src/components/DaoCreator/constants.ts
@@ -15,7 +15,6 @@ export const initialState: CreatorFormState = {
     daoName: '',
     governance: GovernanceType.AZORIUS_ERC20,
     snapshotENS: '',
-    gaslessVoting: false,
   },
   erc20Token: {
     tokenCreationType: TokenCreationType.IMPORTED,

--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -31,16 +31,12 @@ const useBuildDAOTx = () => {
       moduleFractalMasterCopy,
       linearVotingErc20MasterCopy,
       linearVotingErc721MasterCopy,
-      linearVotingErc20V1MasterCopy,
-      linearVotingErc721V1MasterCopy,
       moduleAzoriusMasterCopy,
       freezeGuardAzoriusMasterCopy,
       freezeGuardMultisigMasterCopy,
       freezeVotingErc20MasterCopy,
       freezeVotingErc721MasterCopy,
       freezeVotingMultisigMasterCopy,
-      paymaster,
-      accountAbstraction,
     },
   } = useNetworkConfigStore();
   const { daoKey } = useCurrentDAOKey();
@@ -91,12 +87,8 @@ const useBuildDAOTx = () => {
         moduleFractalMasterCopy,
         linearVotingErc20MasterCopy,
         linearVotingErc721MasterCopy,
-        linearVotingErc20V1MasterCopy,
-        linearVotingErc721V1MasterCopy,
         moduleAzoriusMasterCopy,
-        paymaster,
         votesErc20LockableMasterCopy,
-        accountAbstraction,
         parentAddress,
         parentTokenAddress,
       );
@@ -122,7 +114,6 @@ const useBuildDAOTx = () => {
       const buildSafeTxParams = {
         shouldSetName: true, // We KNOW this will always be true because the Decent UI doesn't allow creating a safe without a name
         shouldSetSnapshot: daoData.snapshotENS !== '',
-        enableGaslessVoting: daoData.gaslessVoting,
       };
 
       // Build Tx bundle based on governance type (Azorius or Multisig)
@@ -156,11 +147,7 @@ const useBuildDAOTx = () => {
       moduleFractalMasterCopy,
       linearVotingErc20MasterCopy,
       linearVotingErc721MasterCopy,
-      linearVotingErc20V1MasterCopy,
-      linearVotingErc721V1MasterCopy,
       moduleAzoriusMasterCopy,
-      paymaster,
-      accountAbstraction,
       governance,
       linearVotingErc721Address,
     ],

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -44,16 +44,12 @@ const useDeployAzorius = () => {
       moduleFractalMasterCopy,
       linearVotingErc20MasterCopy,
       linearVotingErc721MasterCopy,
-      linearVotingErc20V1MasterCopy,
-      linearVotingErc721V1MasterCopy,
       moduleAzoriusMasterCopy,
       freezeGuardAzoriusMasterCopy,
       freezeGuardMultisigMasterCopy,
       freezeVotingErc20MasterCopy,
       freezeVotingErc721MasterCopy,
       freezeVotingMultisigMasterCopy,
-      paymaster,
-      accountAbstraction,
     },
     addressPrefix,
   } = useNetworkConfigStore();
@@ -91,10 +87,9 @@ const useDeployAzorius = () => {
       opts: {
         shouldSetName: boolean;
         shouldSetSnapshot: boolean;
-        enableGaslessVoting: boolean;
       },
     ) => {
-      const { shouldSetName, shouldSetSnapshot, enableGaslessVoting } = opts;
+      const { shouldSetName, shouldSetSnapshot } = opts;
       if (!safeAddress || !canUserCreateProposal || !safe) {
         return;
       }
@@ -163,12 +158,8 @@ const useDeployAzorius = () => {
         moduleFractalMasterCopy,
         linearVotingErc20MasterCopy,
         linearVotingErc721MasterCopy,
-        linearVotingErc20V1MasterCopy,
-        linearVotingErc721V1MasterCopy,
         moduleAzoriusMasterCopy,
-        paymaster,
         votesErc20LockableMasterCopy,
-        accountAbstraction,
         subgraphInfo?.parentAddress ?? undefined,
       );
 
@@ -182,7 +173,6 @@ const useDeployAzorius = () => {
       const safeTx = await daoTxBuilder.buildAzoriusTx({
         shouldSetName,
         shouldSetSnapshot,
-        enableGaslessVoting,
         existingSafeOwners: safe.owners,
       });
 
@@ -249,11 +239,7 @@ const useDeployAzorius = () => {
       moduleFractalMasterCopy,
       linearVotingErc20MasterCopy,
       linearVotingErc721MasterCopy,
-      linearVotingErc20V1MasterCopy,
-      linearVotingErc721V1MasterCopy,
       moduleAzoriusMasterCopy,
-      paymaster,
-      accountAbstraction,
       submitProposal,
       t,
       getParentDAOModules,

--- a/src/models/DaoTxBuilder.ts
+++ b/src/models/DaoTxBuilder.ts
@@ -83,12 +83,10 @@ export class DaoTxBuilder extends BaseTxBuilder {
   public async buildAzoriusTx(params: {
     shouldSetName: boolean;
     shouldSetSnapshot: boolean;
-    enableGaslessVoting: boolean;
     existingSafeOwners?: string[];
   }): Promise<string> {
-    const { shouldSetName, shouldSetSnapshot, existingSafeOwners, enableGaslessVoting } = params;
-    const azoriusTxBuilder =
-      await this.txBuilderFactory.createAzoriusTxBuilder(enableGaslessVoting);
+    const { shouldSetName, shouldSetSnapshot, existingSafeOwners } = params;
+    const azoriusTxBuilder = await this.txBuilderFactory.createAzoriusTxBuilder();
 
     // transactions that must be called by safe
     this.internalTxs = [];
@@ -144,13 +142,6 @@ export class DaoTxBuilder extends BaseTxBuilder {
 
     txs.push(azoriusTxBuilder.buildDeployStrategyTx());
     txs.push(azoriusTxBuilder.buildDeployAzoriusTx());
-
-    // Deploy paymaster and set gasless voting enabled
-    if (enableGaslessVoting) {
-      this.internalTxs.push(azoriusTxBuilder.buildDeployPaymasterTx());
-      this.internalTxs.push(this.buildSetGaslessVotingEnabledTx());
-      this.internalTxs.push(azoriusTxBuilder.buildApproveStrategyOnPaymasterTx());
-    }
 
     // If subDAO and parentAllocation, deploy claim module
     let tokenClaimTx: SafeTransaction | undefined;
@@ -273,17 +264,6 @@ export class DaoTxBuilder extends BaseTxBuilder {
       this.keyValuePairs,
       'updateValues',
       [['snapshotENS'], [this.daoData.snapshotENS]],
-      0,
-      false,
-    );
-  }
-
-  private buildSetGaslessVotingEnabledTx(): SafeTransaction {
-    return buildContractCall(
-      abis.KeyValuePairs,
-      this.keyValuePairs,
-      'updateValues',
-      [['gaslessVotingEnabled'], ['true']],
       0,
       false,
     );

--- a/src/models/TxBuilderFactory.ts
+++ b/src/models/TxBuilderFactory.ts
@@ -40,20 +40,8 @@ export class TxBuilderFactory extends BaseTxBuilder {
   private moduleFractalMasterCopy: Address;
   private linearVotingErc20MasterCopy: Address;
   private linearVotingErc721MasterCopy: Address;
-  private linearVotingErc20V1MasterCopy: Address;
-  private linearVotingErc721V1MasterCopy: Address;
   private moduleAzoriusMasterCopy: Address;
   private votesErc20LockableMasterCopy?: Address;
-  private paymaster: {
-    decentPaymasterV1MasterCopy: Address;
-    linearERC20VotingV1ValidatorV1: Address;
-    linearERC721VotingV1ValidatorV1: Address;
-  };
-
-  private accountAbstraction?: {
-    entryPointv07: Address;
-    lightAccountFactory: Address;
-  };
 
   constructor(
     publicClient: PublicClient,
@@ -75,19 +63,8 @@ export class TxBuilderFactory extends BaseTxBuilder {
     moduleFractalMasterCopy: Address,
     linearVotingErc20MasterCopy: Address,
     linearVotingErc721MasterCopy: Address,
-    linearVotingErc20V1MasterCopy: Address,
-    linearVotingErc721V1MasterCopy: Address,
     moduleAzoriusMasterCopy: Address,
-    paymaster: {
-      decentPaymasterV1MasterCopy: Address;
-      linearERC20VotingV1ValidatorV1: Address;
-      linearERC721VotingV1ValidatorV1: Address;
-    },
     votesErc20LockableMasterCopy?: Address,
-    accountAbstraction?: {
-      entryPointv07: Address;
-      lightAccountFactory: Address;
-    },
     parentAddress?: Address,
     parentTokenAddress?: Address,
   ) {
@@ -111,11 +88,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
     this.moduleFractalMasterCopy = moduleFractalMasterCopy;
     this.linearVotingErc20MasterCopy = linearVotingErc20MasterCopy;
     this.linearVotingErc721MasterCopy = linearVotingErc721MasterCopy;
-    this.linearVotingErc20V1MasterCopy = linearVotingErc20V1MasterCopy;
-    this.linearVotingErc721V1MasterCopy = linearVotingErc721V1MasterCopy;
     this.moduleAzoriusMasterCopy = moduleAzoriusMasterCopy;
-    this.paymaster = paymaster;
-    this.accountAbstraction = accountAbstraction;
   }
 
   public setSafeContract(safeAddress: Address) {
@@ -213,7 +186,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
     );
   }
 
-  public async createAzoriusTxBuilder(gaslessVotingEnabled: boolean) {
+  public async createAzoriusTxBuilder() {
     const azoriusTxBuilder = new AzoriusTxBuilder(
       this.publicClient,
       this.daoData as AzoriusERC20DAO,
@@ -224,13 +197,8 @@ export class TxBuilderFactory extends BaseTxBuilder {
       this.claimErc20MasterCopy,
       this.linearVotingErc20MasterCopy,
       this.linearVotingErc721MasterCopy,
-      this.linearVotingErc20V1MasterCopy,
-      this.linearVotingErc721V1MasterCopy,
       this.moduleAzoriusMasterCopy,
-      gaslessVotingEnabled,
-      this.paymaster,
       this.votesErc20LockableMasterCopy,
-      this.accountAbstraction,
       this.parentAddress,
       this.parentTokenAddress,
     );

--- a/src/pages/dao/edit/governance/SafeEditGovernancePage.tsx
+++ b/src/pages/dao/edit/governance/SafeEditGovernancePage.tsx
@@ -61,7 +61,6 @@ export function SafeEditGovernancePage() {
     deployAzorius(daoData as AzoriusERC20DAO | AzoriusERC721DAO | SubDAO, customNonce, {
       shouldSetName,
       shouldSetSnapshot,
-      enableGaslessVoting: daoData.gaslessVoting,
     });
   };
 

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -74,7 +74,6 @@ export type DAOEssentials = {
   daoName: string;
   governance: GovernanceType;
   snapshotENS: string;
-  gaslessVoting: boolean;
 };
 
 export type DAOGovernorERC20Token<T = bigint> = {


### PR DESCRIPTION
Fixes [ENG-695](https://linear.app/decent-labs/issue/ENG-695/remove-gasless-voting-contracts-and-configurations-from-deploy-dao)

**Description:**

This change removes the option and associated logic for setting up gasless voting features (including paymaster deployment and V1 voting strategy configuration) during the initial DAO creation and deployment process. The setup of these features is intended to be handled separately, likely post-deployment via DAO settings.

**Motivation:**

Bundling the setup of gasless voting (which involves deploying a paymaster contract, setting specific key-value pairs, and potentially using different V1 strategy master copies) into the core DAO deployment transaction batch significantly increased its complexity. This complexity wasn't strictly necessary for the fundamental creation of the DAO (Safe + core modules + standard voting strategy).

Decoupling these concerns provides several benefits:
1.  **Simplifies Initial Deployment:** Reduces the number of transactions and conditional logic in the critical DAO creation batch, making it more robust and easier to debug.
2.  **Improves Focus:** Allows the DAO creation process to focus solely on deploying the essential components.
3.  **Increases Flexibility:** Enables gasless voting setup to be managed independently, potentially allowing for different configurations or even different paymaster implementations in the future without altering the core deployment flow.

**Changes:**

*   **DAO Creator UI State:**
    *   Removed the `gaslessVoting` boolean flag from `CreatorFormState` (`src/components/DaoCreator/constants.ts`) and `DAOEssentials` (`src/types/createDAO.ts`).

*   **Deployment Hooks (`useBuildDAOTx`, `useDeployAzorius`):**
    *   Removed the `enableGaslessVoting` parameter from the deployment functions and calls.
    *   Removed the passing of V1 voting strategy master copies (`linearVotingErc20V1MasterCopy`, `linearVotingErc721V1MasterCopy`), `paymaster`, and `accountAbstraction` configurations to the `TxBuilderFactory`. These are no longer needed *during the initial deployment phase*.

*   **Transaction Builders (`AzoriusTxBuilder`, `DaoTxBuilder`, `TxBuilderFactory`):**
    *   Removed the `gaslessVotingEnabled` parameter and internal state from `AzoriusTxBuilder`.
    *   Removed the V1 strategy master copies, `paymaster`, and `accountAbstraction` parameters from the `AzoriusTxBuilder` constructor and the `createAzoriusTxBuilder` method in `TxBuilderFactory`.
    *   Simplified `AzoriusTxBuilder` methods (`buildDeployStrategyTx`, `setupLinearERC20VotingStrategy`, `setupLinearERC721VotingStrategy`) to *always* use the standard (non-V1) voting strategy master copies and setup parameters. Removed conditional logic based on `gaslessVotingEnabled`.
    *   Removed methods specifically for gasless setup from `AzoriusTxBuilder`: `buildDeployPaymasterTx`, `buildApproveStrategyOnPaymasterTx`.
    *   Removed the transaction calls related to gasless setup (deploying paymaster, setting KV pair, approving strategy) within `DaoTxBuilder.buildAzoriusTx`. Removed the unused `buildSetGaslessVotingEnabledTx` method.

*   **Governance Editing (`SafeEditGovernancePage`):**
    *   Removed the `enableGaslessVoting` parameter passed during Azorius deployment when editing governance.

**Impact:**

*   The initial DAO deployment transaction batch is now simpler and only includes the deployment of the Safe, core modules (Azorius, Fractal), the chosen standard voting strategy, and optionally the governance token/claim module.
*   Gasless voting features are *not* configured automatically upon DAO creation. Users will need to enable and configure these features through a separate process (e.g., DAO settings) after the DAO is deployed.
*   Code related to handling V1 strategies and paymaster setup *during initial deployment* has been removed, simplifying the relevant hooks and transaction builders.