### PR TITLE
`[ENG-696]` refactor(network-config): Remove explicit accountAbstractionSupported flag

### DIFF
--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -123,7 +123,6 @@ export const baseConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
-  accountAbstractionSupported: false,
 };
 
 export default baseConfig;

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -138,7 +138,6 @@ export const mainnetConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
-  accountAbstractionSupported: true,
   bundlerMinimumStake: 100_000_000_000_000_000n, // 0.1 ETH
 };
 

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -123,7 +123,6 @@ export const optimismConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
-  accountAbstractionSupported: false,
 };
 
 export default optimismConfig;

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -123,7 +123,6 @@ export const polygonConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
-  accountAbstractionSupported: false,
 };
 
 export default polygonConfig;

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -132,7 +132,6 @@ export const sepoliaConfig: NetworkConfig = {
     GovernanceType.AZORIUS_ERC20,
     GovernanceType.AZORIUS_ERC721,
   ],
-  accountAbstractionSupported: true,
   bundlerMinimumStake: 10_000_000_000_000_000n, // 0.01 ETH
 };
 

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -93,12 +93,10 @@ type NetworkConfigBase = {
     };
   };
   createOptions: GovernanceType[];
-  accountAbstractionSupported: boolean;
 };
 
 // Type for networks *with* Account Abstraction
 type NetworkConfigWithAA = NetworkConfigBase & {
-  accountAbstractionSupported: true;
   contracts: ContractsBase & {
     // accountAbstraction is REQUIRED here
     accountAbstraction: {
@@ -112,7 +110,6 @@ type NetworkConfigWithAA = NetworkConfigBase & {
 
 // Type for networks *without* Account Abstraction
 type NetworkConfigWithoutAA = NetworkConfigBase & {
-  accountAbstractionSupported: false;
   contracts: ContractsBase & {
     // accountAbstraction is OPTIONAL and UNDEFINED here
     accountAbstraction?: undefined;


### PR DESCRIPTION
Fixes [ENG-696](https://linear.app/decent-labs/issue/ENG-696/remove-unnecessary-accountabstractionsupported-flag-from-network)

This commit removes the explicit `accountAbstractionSupported` boolean flag from the `NetworkConfig` type definition (`src/types/network.ts`) and all individual network configuration files (`src/providers/NetworkConfig/networks/*.ts`).

**Reasoning:**

The `NetworkConfig` type was previously refactored into a discriminated union, where the presence or absence of the `contracts.accountAbstraction` and `bundlerMinimumStake` properties already served to distinguish between networks that support Account Abstraction (AA) and those that do not.

The `accountAbstractionSupported` boolean flag became redundant, as its value was directly tied to the structure defined by the discriminated union. Checking for AA support can be done simply by checking for the existence of the `contracts.accountAbstraction` property (or `bundlerMinimumStake` where relevant) on a `NetworkConfig` object, leveraging TypeScript's type narrowing.

**Changes:**

*   Removed `accountAbstractionSupported: boolean` from `NetworkConfigBase` in `src/types/network.ts`.
*   Removed `accountAbstractionSupported: true` and `accountAbstractionSupported: false` from the `NetworkConfigWithAA` and `NetworkConfigWithoutAA` types respectively.
*   Removed the `accountAbstractionSupported: <boolean>` line from the configuration objects in `base.ts`, `mainnet.ts`, `optimism.ts`, `polygon.ts`, and `sepolia.ts`.

**Benefit:**

This change simplifies the `NetworkConfig` type and removes unnecessary boilerplate configuration from each network file, relying solely on the structure defined by the discriminated union to indicate AA support.