### PR TITLE
`[ENG-697]` refactor(settings): Improve clarity of AA support and staking logic

### DIFF
--- a/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
+++ b/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
@@ -62,11 +62,11 @@ export function SafeGeneralSettingsPage() {
     bundlerMinimumStake,
   } = useNetworkConfigStore();
   const { depositInfo } = useDepositInfo(paymasterAddress);
-  const gaslessStakingFeatureEnabled = bundlerMinimumStake !== undefined;
+  const accountAbstractionSupported = bundlerMinimumStake !== undefined;
+  const stakingRequired = accountAbstractionSupported && bundlerMinimumStake > 0n;
 
   const isMultisigGovernance = votingStrategyType === GovernanceType.MULTISIG;
-  const gaslessVotingSupported =
-    !isMultisigGovernance && accountAbstraction?.entryPointv07 !== undefined;
+  const gaslessVotingSupported = !isMultisigGovernance && accountAbstractionSupported;
 
   const safeAddress = safe?.address;
 
@@ -199,7 +199,7 @@ export function SafeGeneralSettingsPage() {
       });
 
       // Add stake for Paymaster if not enough
-      if (gaslessStakingFeatureEnabled) {
+      if (stakingRequired) {
         const stakedAmount = depositInfo?.stake || 0n;
 
         if (paymasterAddress === null || stakedAmount < bundlerMinimumStake) {


### PR DESCRIPTION
Fixes [ENG-697](https://linear.app/decent-labs/issue/ENG-697/refactor-aa-support-and-staking-logic-in-general-settings-for-clarity)

This commit refactors variable naming and logic within `SafeGeneralSettingsPage.tsx` related to Account Abstraction (AA) support and bundler staking requirements for improved clarity and accuracy.

**Changes:**

1.  **Renamed `gaslessStakingFeatureEnabled` to `accountAbstractionSupported`:**
    *   This variable, derived from `bundlerMinimumStake !== undefined`, now more accurately reflects that its purpose is to indicate whether the current network *supports* AA features based on the presence of related configuration. The previous name implied it was solely about enabling staking.

2.  **Introduced `stakingRequired`:**
    *   A new boolean variable `stakingRequired` is introduced (`accountAbstractionSupported && bundlerMinimumStake > 0n`).
    *   This clearly differentiates between networks that merely *support* AA and those where staking is *actually required* (i.e., AA is supported *and* the defined minimum stake is greater than zero).

3.  **Updated Staking Condition:**
    *   The conditional check (`if (...)`) for adding stake to the paymaster now correctly uses the more precise `stakingRequired` variable. This ensures stake is only added when AA is supported *and* a non-zero stake is necessary according to the network config.

4.  **Updated `gaslessVotingSupported`:**
    *   The condition for determining if gasless voting is supported (`gaslessVotingSupported`) now uses the clearer `accountAbstractionSupported` flag, aligning it with the explicit network configuration flag rather than checking for the presence of specific contract addresses (`accountAbstraction?.entryPointv07`).

**Benefit:**

These changes enhance code readability by using more descriptive variable names. They also make the logic for handling paymaster staking more precise, ensuring it only triggers when a stake is genuinely required by the network configuration (support exists and stake > 0).