### PR TITLE
`[ENG-698]` fix(strategy): Explicitly check for AA config when setting up gasless Hats strategies

### DIFF
--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -186,31 +186,41 @@ export default function useCreateRoles() {
             allowFailure: false,
           });
 
-        if (gaslessVotingFeatureEnabled && !accountAbstraction) {
-          throw new Error('Account abstraction is not enabled');
+        let encodedStrategyInitParams: Hex;
+
+        if (gaslessVotingFeatureEnabled) {
+          if (!accountAbstraction) {
+            throw new Error('Account abstraction not found');
+          }
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams),
+            [
+              safeAddress, // owner
+              votesToken.address, // governance token
+              moduleAzoriusAddress, // Azorius module
+              existingVotingPeriod,
+              existingQuorumNumerator,
+              existingBasisNumerator,
+              hatsProtocol,
+              whitelistedHatsIds,
+              accountAbstraction.lightAccountFactory,
+            ],
+          );
+        } else {
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC20VotingWithWhitelistSetupParams),
+            [
+              safeAddress, // owner
+              votesToken.address, // governance token
+              moduleAzoriusAddress, // Azorius module
+              existingVotingPeriod,
+              existingQuorumNumerator,
+              existingBasisNumerator,
+              hatsProtocol,
+              whitelistedHatsIds,
+            ],
+          );
         }
-        const encodedStrategyInitParams = gaslessVotingFeatureEnabled
-          ? encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams), [
-              safeAddress, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumNumerator,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-              accountAbstraction!.lightAccountFactory,
-            ])
-          : encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistSetupParams), [
-              safeAddress, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumNumerator,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-            ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: abis.LinearERC20VotingWithHatsProposalCreation,
@@ -301,34 +311,44 @@ export default function useCreateRoles() {
             allowFailure: false,
           });
 
-        if (gaslessVotingFeatureEnabled && !accountAbstraction) {
-          throw new Error('Account abstraction is not enabled');
+        let encodedStrategyInitParams: Hex;
+
+        if (gaslessVotingFeatureEnabled) {
+          if (!accountAbstraction) {
+            throw new Error('Account abstraction not found');
+          }
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
+            [
+              safeAddress, // owner
+              erc721Tokens.map(token => token.address), // governance tokens addresses
+              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
+              moduleAzoriusAddress, // Azorius module
+              existingVotingPeriod,
+              existingQuorumThreshold,
+              existingBasisNumerator,
+              hatsProtocol,
+              whitelistedHatsIds,
+              accountAbstraction.lightAccountFactory,
+            ],
+          );
+        } else {
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC721VotingWithWhitelistSetupParams),
+            [
+              safeAddress, // owner
+              erc721Tokens.map(token => token.address), // governance tokens addresses
+              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
+              moduleAzoriusAddress, // Azorius module
+              existingVotingPeriod,
+              existingQuorumThreshold,
+              existingBasisNumerator,
+              hatsProtocol,
+              whitelistedHatsIds,
+            ],
+          );
         }
 
-        const encodedStrategyInitParams = gaslessVotingFeatureEnabled
-          ? encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams), [
-              safeAddress, // owner
-              erc721Tokens.map(token => token.address), // governance tokens addresses
-              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumThreshold,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-              accountAbstraction!.lightAccountFactory,
-            ])
-          : encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistSetupParams), [
-              safeAddress, // owner
-              erc721Tokens.map(token => token.address), // governance tokens addresses
-              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumThreshold,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-            ]);
         const encodedStrategySetupData = encodeFunctionData({
           abi: abis.LinearERC721VotingWithHatsProposalCreation,
           functionName: 'setUp',

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -186,41 +186,29 @@ export default function useCreateRoles() {
             allowFailure: false,
           });
 
-        let encodedStrategyInitParams: Hex;
-
-        if (gaslessVotingFeatureEnabled) {
-          if (!accountAbstraction) {
-            throw new Error('Account abstraction not found');
-          }
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams),
-            [
-              safeAddress, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumNumerator,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-              accountAbstraction.lightAccountFactory,
-            ],
-          );
-        } else {
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC20VotingWithWhitelistSetupParams),
-            [
-              safeAddress, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumNumerator,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-            ],
-          );
-        }
+        const encodedStrategyInitParams =
+          gaslessVotingFeatureEnabled && accountAbstraction
+            ? encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams), [
+                safeAddress, // owner
+                votesToken.address, // governance token
+                moduleAzoriusAddress, // Azorius module
+                existingVotingPeriod,
+                existingQuorumNumerator,
+                existingBasisNumerator,
+                hatsProtocol,
+                whitelistedHatsIds,
+                accountAbstraction.lightAccountFactory,
+              ])
+            : encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistSetupParams), [
+                safeAddress, // owner
+                votesToken.address, // governance token
+                moduleAzoriusAddress, // Azorius module
+                existingVotingPeriod,
+                existingQuorumNumerator,
+                existingBasisNumerator,
+                hatsProtocol,
+                whitelistedHatsIds,
+              ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: abis.LinearERC20VotingWithHatsProposalCreation,
@@ -311,43 +299,34 @@ export default function useCreateRoles() {
             allowFailure: false,
           });
 
-        let encodedStrategyInitParams: Hex;
-
-        if (gaslessVotingFeatureEnabled) {
-          if (!accountAbstraction) {
-            throw new Error('Account abstraction not found');
-          }
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
-            [
-              safeAddress, // owner
-              erc721Tokens.map(token => token.address), // governance tokens addresses
-              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumThreshold,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-              accountAbstraction.lightAccountFactory,
-            ],
-          );
-        } else {
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC721VotingWithWhitelistSetupParams),
-            [
-              safeAddress, // owner
-              erc721Tokens.map(token => token.address), // governance tokens addresses
-              erc721Tokens.map(token => token.votingWeight), // governance tokens weights
-              moduleAzoriusAddress, // Azorius module
-              existingVotingPeriod,
-              existingQuorumThreshold,
-              existingBasisNumerator,
-              hatsProtocol,
-              whitelistedHatsIds,
-            ],
-          );
-        }
+        const encodedStrategyInitParams =
+          gaslessVotingFeatureEnabled && accountAbstraction
+            ? encodeAbiParameters(
+                parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
+                [
+                  safeAddress, // owner
+                  erc721Tokens.map(token => token.address), // governance tokens addresses
+                  erc721Tokens.map(token => token.votingWeight), // governance tokens weights
+                  moduleAzoriusAddress, // Azorius module
+                  existingVotingPeriod,
+                  existingQuorumThreshold,
+                  existingBasisNumerator,
+                  hatsProtocol,
+                  whitelistedHatsIds,
+                  accountAbstraction.lightAccountFactory,
+                ],
+              )
+            : encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistSetupParams), [
+                safeAddress, // owner
+                erc721Tokens.map(token => token.address), // governance tokens addresses
+                erc721Tokens.map(token => token.votingWeight), // governance tokens weights
+                moduleAzoriusAddress, // Azorius module
+                existingVotingPeriod,
+                existingQuorumThreshold,
+                existingBasisNumerator,
+                hatsProtocol,
+                whitelistedHatsIds,
+              ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: abis.LinearERC721VotingWithHatsProposalCreation,

--- a/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
@@ -10,7 +10,6 @@ import {
   encodePacked,
   getContract,
   getCreate2Address,
-  Hex,
   keccak256,
   parseAbiParameters,
   zeroAddress,
@@ -171,41 +170,29 @@ export function SafePermissionsCreateProposal() {
         const quorumDenominator =
           await linearERC20VotingMasterCopyContract.read.QUORUM_DENOMINATOR();
 
-        let encodedStrategyInitParams: Hex;
-
-        if (gaslessVotingFeatureEnabled) {
-          if (!accountAbstraction) {
-            throw new Error('Account abstraction not found');
-          }
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams),
-            [
-              safe.address, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              Number(votingStrategy.votingPeriod.value),
-              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-              accountAbstraction.lightAccountFactory, // light account factory
-            ],
-          );
-        } else {
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC20VotingWithWhitelistSetupParams),
-            [
-              safe.address, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              Number(votingStrategy.votingPeriod.value),
-              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-            ],
-          );
-        }
+        const encodedStrategyInitParams =
+          gaslessVotingFeatureEnabled && accountAbstraction
+            ? encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams), [
+                safe.address, // owner
+                votesToken.address, // governance token
+                moduleAzoriusAddress, // Azorius module
+                Number(votingStrategy.votingPeriod.value),
+                (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
+                500000n,
+                hatsProtocol, // hats protocol
+                [], // whitelisted hat ids
+                accountAbstraction.lightAccountFactory, // light account factory
+              ])
+            : encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistSetupParams), [
+                safe.address, // owner
+                votesToken.address, // governance token
+                moduleAzoriusAddress, // Azorius module
+                Number(votingStrategy.votingPeriod.value),
+                (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
+                500000n,
+                hatsProtocol, // hats protocol
+                [], // whitelisted hat ids
+              ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: gaslessVotingFeatureEnabled
@@ -265,43 +252,34 @@ export function SafePermissionsCreateProposal() {
           throw new Error('Voting strategy or NFT votes tokens not found');
         }
 
-        let encodedStrategyInitParams: Hex;
-
-        if (gaslessVotingFeatureEnabled) {
-          if (!accountAbstraction) {
-            throw new Error('Account abstraction not found');
-          }
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
-            [
-              safe.address, // owner
-              erc721Tokens.map(token => token.address), // governance token
-              erc721Tokens.map(token => token.votingWeight),
-              moduleAzoriusAddress,
-              Number(votingStrategy.votingPeriod.value),
-              proposerThreshold.bigintValue,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-              accountAbstraction.lightAccountFactory, // light account factory
-            ],
-          );
-        } else {
-          encodedStrategyInitParams = encodeAbiParameters(
-            parseAbiParameters(linearERC721VotingWithWhitelistSetupParams),
-            [
-              safe.address, // owner
-              erc721Tokens.map(token => token.address), // governance token
-              erc721Tokens.map(token => token.votingWeight),
-              moduleAzoriusAddress,
-              Number(votingStrategy.votingPeriod.value),
-              proposerThreshold.bigintValue,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-            ],
-          );
-        }
+        const encodedStrategyInitParams =
+          gaslessVotingFeatureEnabled && accountAbstraction
+            ? encodeAbiParameters(
+                parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
+                [
+                  safe.address, // owner
+                  erc721Tokens.map(token => token.address), // governance token
+                  erc721Tokens.map(token => token.votingWeight),
+                  moduleAzoriusAddress,
+                  Number(votingStrategy.votingPeriod.value),
+                  proposerThreshold.bigintValue,
+                  500000n,
+                  hatsProtocol, // hats protocol
+                  [], // whitelisted hat ids
+                  accountAbstraction.lightAccountFactory, // light account factory
+                ],
+              )
+            : encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistSetupParams), [
+                safe.address, // owner
+                erc721Tokens.map(token => token.address), // governance token
+                erc721Tokens.map(token => token.votingWeight),
+                moduleAzoriusAddress,
+                Number(votingStrategy.votingPeriod.value),
+                proposerThreshold.bigintValue,
+                500000n,
+                hatsProtocol, // hats protocol
+                [], // whitelisted hat ids
+              ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: gaslessVotingFeatureEnabled

--- a/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
@@ -10,6 +10,7 @@ import {
   encodePacked,
   getContract,
   getCreate2Address,
+  Hex,
   keccak256,
   parseAbiParameters,
   zeroAddress,
@@ -170,31 +171,41 @@ export function SafePermissionsCreateProposal() {
         const quorumDenominator =
           await linearERC20VotingMasterCopyContract.read.QUORUM_DENOMINATOR();
 
-        if (gaslessVotingFeatureEnabled && !accountAbstraction) {
-          throw new Error('Account abstraction not found');
+        let encodedStrategyInitParams: Hex;
+
+        if (gaslessVotingFeatureEnabled) {
+          if (!accountAbstraction) {
+            throw new Error('Account abstraction not found');
+          }
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams),
+            [
+              safe.address, // owner
+              votesToken.address, // governance token
+              moduleAzoriusAddress, // Azorius module
+              Number(votingStrategy.votingPeriod.value),
+              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
+              500000n,
+              hatsProtocol, // hats protocol
+              [], // whitelisted hat ids
+              accountAbstraction.lightAccountFactory, // light account factory
+            ],
+          );
+        } else {
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC20VotingWithWhitelistSetupParams),
+            [
+              safe.address, // owner
+              votesToken.address, // governance token
+              moduleAzoriusAddress, // Azorius module
+              Number(votingStrategy.votingPeriod.value),
+              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
+              500000n,
+              hatsProtocol, // hats protocol
+              [], // whitelisted hat ids
+            ],
+          );
         }
-        const encodedStrategyInitParams = gaslessVotingFeatureEnabled
-          ? encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistV1SetupParams), [
-              safe.address, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              Number(votingStrategy.votingPeriod.value),
-              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-              accountAbstraction!.lightAccountFactory, // light account factory
-            ])
-          : encodeAbiParameters(parseAbiParameters(linearERC20VotingWithWhitelistSetupParams), [
-              safe.address, // owner
-              votesToken.address, // governance token
-              moduleAzoriusAddress, // Azorius module
-              Number(votingStrategy.votingPeriod.value),
-              (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-            ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: gaslessVotingFeatureEnabled
@@ -254,33 +265,43 @@ export function SafePermissionsCreateProposal() {
           throw new Error('Voting strategy or NFT votes tokens not found');
         }
 
-        if (gaslessVotingFeatureEnabled && !accountAbstraction) {
-          throw new Error('Account abstraction not found');
+        let encodedStrategyInitParams: Hex;
+
+        if (gaslessVotingFeatureEnabled) {
+          if (!accountAbstraction) {
+            throw new Error('Account abstraction not found');
+          }
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams),
+            [
+              safe.address, // owner
+              erc721Tokens.map(token => token.address), // governance token
+              erc721Tokens.map(token => token.votingWeight),
+              moduleAzoriusAddress,
+              Number(votingStrategy.votingPeriod.value),
+              proposerThreshold.bigintValue,
+              500000n,
+              hatsProtocol, // hats protocol
+              [], // whitelisted hat ids
+              accountAbstraction.lightAccountFactory, // light account factory
+            ],
+          );
+        } else {
+          encodedStrategyInitParams = encodeAbiParameters(
+            parseAbiParameters(linearERC721VotingWithWhitelistSetupParams),
+            [
+              safe.address, // owner
+              erc721Tokens.map(token => token.address), // governance token
+              erc721Tokens.map(token => token.votingWeight),
+              moduleAzoriusAddress,
+              Number(votingStrategy.votingPeriod.value),
+              proposerThreshold.bigintValue,
+              500000n,
+              hatsProtocol, // hats protocol
+              [], // whitelisted hat ids
+            ],
+          );
         }
-        const encodedStrategyInitParams = gaslessVotingFeatureEnabled
-          ? encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistV1SetupParams), [
-              safe.address, // owner
-              erc721Tokens.map(token => token.address), // governance token
-              erc721Tokens.map(token => token.votingWeight),
-              moduleAzoriusAddress,
-              Number(votingStrategy.votingPeriod.value),
-              proposerThreshold.bigintValue,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-              accountAbstraction!.lightAccountFactory, // light account factory
-            ])
-          : encodeAbiParameters(parseAbiParameters(linearERC721VotingWithWhitelistSetupParams), [
-              safe.address, // owner
-              erc721Tokens.map(token => token.address), // governance token
-              erc721Tokens.map(token => token.votingWeight),
-              moduleAzoriusAddress,
-              Number(votingStrategy.votingPeriod.value),
-              proposerThreshold.bigintValue,
-              500000n,
-              hatsProtocol, // hats protocol
-              [], // whitelisted hat ids
-            ]);
 
         const encodedStrategySetupData = encodeFunctionData({
           abi: gaslessVotingFeatureEnabled


### PR DESCRIPTION
Fixes [ENG-698](https://linear.app/decent-labs/issue/ENG-698/ensure-aa-config-exists-before-setting-up-gasless-hats-strategies)

Refactors the logic for encoding setup parameters for Hats-whitelisted voting strategies (both ERC20 and ERC721) in `useCreateRoles` and `SafePermissionsCreateProposal`.

Previously, the code implicitly relied on a non-null assertion (`!`) on the `accountAbstraction` configuration when `gaslessVotingFeatureEnabled` was true. This could lead to runtime errors if the feature was enabled on a network lacking the necessary AA configuration, without an explicit check beforehand.

This change introduces an explicit check:
1.  If `gaslessVotingFeatureEnabled` is true, it now verifies that `accountAbstraction` configuration exists.
2.  If AA config is missing when gasless is enabled, it throws a clear error (`Account abstraction not found`).
3.  If both are present, it uses the V1 (gasless-compatible) setup parameters.
4.  If `gaslessVotingFeatureEnabled` is false, it uses the standard setup parameters.

This ensures more robust error handling and guarantees that the V1 strategy setup (requiring `lightAccountFactory`) is only attempted when both the feature flag is enabled and the required network configuration is present. It aligns the logic for handling this scenario consistently across `useCreateRoles` and `SafePermissionsCreateProposal`.