### PR TITLE
`[ENG-699]` refactor: Update paymasterAddress type to null in DAO info store

### DIFF
--- a/src/store/daoInfo/useDaoInfoStore.ts
+++ b/src/store/daoInfo/useDaoInfoStore.ts
@@ -7,7 +7,7 @@ export const initialDaoInfoStore: IDAO = {
   subgraphInfo: null,
   modules: null,
   gaslessVotingEnabled: false,
-  paymasterAddress: undefined,
+  paymasterAddress: null,
 };
 
 interface GaslessVotingDaoData {

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -161,10 +161,7 @@ export interface IDAO {
 
   // @todo: Preferrably should live in governance store. Using here fore convenience till we refactor governance store for zustand.
   gaslessVotingEnabled: boolean;
-
-  // null -- Defined: paymaster does not exist.
-  // undefined -- Unset. Should not be taken to mean anything. Does not equate to a "loading" state.
-  paymasterAddress: Address | null | undefined;
+  paymasterAddress: Address | null;
 }
 
 export interface GovernanceActivity extends ActivityBase {

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -10,16 +10,11 @@ import { TreasuryActions } from '../providers/App/treasury/action';
 import { ERC721TokenData, VotesTokenData } from './account';
 import { FreezeGuardType, FreezeVotingType } from './daoGovernance';
 import { AzoriusProposal, MultisigProposal, ProposalData } from './daoProposal';
+import { DefiBalance, NFTBalance, TokenBalance, TokenEventType, TransferType } from './daoTreasury';
 import { ProposalTemplate } from './proposalBuilder';
 import { SafeInfoResponseWithGuard } from './safeGlobal';
-import {
-  DefiBalance,
-  NFTBalance,
-  SnapshotProposal,
-  TokenBalance,
-  TokenEventType,
-  TransferType,
-} from '.';
+import { SnapshotProposal } from './snapshot';
+
 /**
  * The possible states of a DAO proposal, for both Token Voting (Azorius) and Multisignature
  * (Safe) governance, as well as Snapshot specific states.
@@ -161,6 +156,8 @@ export interface IDAO {
 
   // @todo: Preferrably should live in governance store. Using here fore convenience till we refactor governance store for zustand.
   gaslessVotingEnabled: boolean;
+
+  // null -- Paymaster contract has not been deployed at the address we expect it to be at
   paymasterAddress: Address | null;
 }
 


### PR DESCRIPTION
Fixes [ENG-699](https://linear.app/decent-labs/issue/ENG-699/standardize-paymasteraddress-state-in-dao-info-store-to-use-null)

This change modifies the `paymasterAddress` property in the `IDAO` interface and the initial DAO info store to use `null` instead of `undefined`. This adjustment clarifies the intended state of the paymaster address, ensuring consistency in how it is represented across the codebase.