### PR TITLE
`[ENG-530]` fix: Update navigation routes from proposals to dao

### DIFF
--- a/src/components/ProposalTemplates/ProposalTemplateCard.tsx
+++ b/src/components/ProposalTemplates/ProposalTemplateCard.tsx
@@ -47,7 +47,7 @@ export default function ProposalTemplateCard({
   const successCallback = useCallback(() => {
     if (safe?.address) {
       // Redirecting to proposals page so that user will see Proposal for Proposal Template creation
-      navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+      navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
     }
   }, [navigate, safe, addressPrefix]);
 

--- a/src/components/ui/modals/ProposalTemplateModal.tsx
+++ b/src/components/ui/modals/ProposalTemplateModal.tsx
@@ -91,7 +91,7 @@ export default function ProposalTemplateModal({
 
   const successCallback = () => {
     if (safe?.address) {
-      navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+      navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
       onClose();
     }
   };

--- a/src/components/ui/modals/Stake.tsx
+++ b/src/components/ui/modals/Stake.tsx
@@ -35,7 +35,7 @@ export default function StakeModal({ close }: { close: () => void }) {
       await handleStake(inputAmount?.bigintValue);
       close();
       if (safe?.address) {
-        navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+        navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
       }
     }
   };

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -213,7 +213,7 @@ const useDeployAzorius = () => {
         pendingToastMessage: t('modifyGovernanceSetAzoriusProposalPendingMessage'),
         successToastMessage: t('proposalCreateSuccessToastMessage', { ns: 'proposal' }),
         failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
-        successCallback: () => navigate(DAO_ROUTES.proposals.relative(addressPrefix, safeAddress)),
+        successCallback: () => navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress)),
       });
     },
     [

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -1825,7 +1825,7 @@ export default function useCreateRoles() {
           failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
           successCallback: () => {
             if (safeAddress) {
-              navigate(DAO_ROUTES.proposals.relative(addressPrefix, safeAddress));
+              navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress));
             }
           },
         });

--- a/src/pages/dao/proposals/[proposalId]/index.tsx
+++ b/src/pages/dao/proposals/[proposalId]/index.tsx
@@ -70,7 +70,7 @@ export function SafeProposalDetailsPage() {
         breadcrumbs={[
           {
             terminus: t('proposals', { ns: 'breadcrumbs' }),
-            path: DAO_ROUTES.proposals.relative(addressPrefix, safe.address),
+            path: DAO_ROUTES.dao.relative(addressPrefix, safe.address),
           },
           {
             terminus: t('proposal', {

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -52,7 +52,7 @@ export function SafeProposalWithActionsCreatePage() {
   const pageHeaderBreadcrumbs = [
     {
       terminus: t('proposals', { ns: 'breadcrumbs' }),
-      path: DAO_ROUTES.proposals.relative(addressPrefix, safe.address),
+      path: DAO_ROUTES.dao.relative(addressPrefix, safe.address),
     },
     {
       terminus: t('proposalNew', { ns: 'breadcrumbs' }),
@@ -61,7 +61,7 @@ export function SafeProposalWithActionsCreatePage() {
   ];
 
   const pageHeaderButtonClickHandler = () => {
-    navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+    navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
   };
 
   const stepButtons = ({

--- a/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
@@ -49,7 +49,7 @@ export function SafeProposalCreatePage() {
   const pageHeaderBreadcrumbs = [
     {
       terminus: t('proposals', { ns: 'breadcrumbs' }),
-      path: DAO_ROUTES.proposals.relative(addressPrefix, safe.address),
+      path: DAO_ROUTES.dao.relative(addressPrefix, safe.address),
     },
     {
       terminus: t('proposalNew', { ns: 'breadcrumbs' }),
@@ -58,7 +58,7 @@ export function SafeProposalCreatePage() {
   ];
 
   const pageHeaderButtonClickHandler = () => {
-    navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+    navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
   };
 
   const stepButtons = ({

--- a/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
@@ -149,7 +149,7 @@ export function SafeSablierProposalCreatePage() {
   const pageHeaderBreadcrumbs = [
     {
       terminus: t('proposals', { ns: 'breadcrumbs' }),
-      path: DAO_ROUTES.proposals.relative(addressPrefix, safe.address),
+      path: DAO_ROUTES.dao.relative(addressPrefix, safe.address),
     },
     {
       terminus: t('proposalNew', { ns: 'breadcrumbs' }),
@@ -158,7 +158,7 @@ export function SafeSablierProposalCreatePage() {
   ];
 
   const pageHeaderButtonClickHandler = () => {
-    navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
+    navigate(DAO_ROUTES.dao.relative(addressPrefix, safe.address));
   };
 
   const stepButtons = ({

--- a/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
+++ b/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
@@ -271,7 +271,6 @@ export function SafeGeneralSettingsPage() {
       values,
       calldatas,
     };
-
     submitProposal({
       safeAddress: safe?.address,
       proposalData,
@@ -281,7 +280,7 @@ export function SafeGeneralSettingsPage() {
       failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
       successCallback: () => {
         if (safeAddress) {
-          navigate(DAO_ROUTES.proposals.relative(addressPrefix, safeAddress));
+          navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress));
         }
       },
     });


### PR DESCRIPTION
Ah found it. So we were still navigating to the old 'proposals' page. We had set that route to redirect back to the home page if hit. So `react-router-dom` was completely ignoring the safeAddress and redirecting. 

Now I'm not sure why react-router was preserving the old query params of the previous dao and using that for the redirect 🤷🏽. But updating the path from the old proposals page to the home page of the new DAO fixes this issue. 


## Changes
- ProposalTemplateCard.tsx: Change navigation route for success callback
- ProposalTemplateModal.tsx: Change navigation route for success callback
- Stake.tsx: Change navigation route after staking
- useDeployAzorius.ts: Update success callback navigation route
- useCreateRoles.ts: Update success callback navigation route
- index.tsx: Change breadcrumb path navigation route
- SafeProposalWithActionsCreatePage.tsx: Update navigation route for breadcrumbs and button click
- SafeProposalCreatePage.tsx: Update navigation route for breadcrumbs and button click
- SafeSablierProposalCreatePage.tsx: Update navigation route for breadcrumbs and button click
- SafeGeneralSettingsPage.tsx: Update navigation route for success callback