### PR TITLE
`[ENG-715]` should check streams length too if transactions is empty

### DIFF
--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -170,11 +170,14 @@ export function ProposalBuilder({
 
         const trimmedTitle = title.trim();
 
+        const noTransactionsOrStreams =
+          transactions.length === 0 &&
+          (formikProps.values as CreateSablierProposalForm).streams?.length === 0;
         const createProposalButtonDisabled =
           !canUserCreateProposal ||
           Object.keys(formikProps.errors).length > 0 ||
           !trimmedTitle ||
-          transactions.length === 0 ||
+          noTransactionsOrStreams ||
           pendingCreateTx;
 
         const renderButtons = (step: CreateProposalSteps) => {


### PR DESCRIPTION
### Summary

`ProposalBuilder` has been used with `CreateProposalForm` type validation while it can be `CreateSablierProposalForm` type within stream proposal creator.

### History

* resolved validation schema issue on https://github.com/decentdao/decent-app/pull/2776
* stream proposal blocked by this commit again https://github.com/decentdao/decent-app/commit/18e56350b4882b47011b158b21e41588567ee620