### PR TITLE
`[ENG-716]` use parentFormikValue to keep inputValue of BigIntInput to be synced with outside changes

### DIFF
--- a/src/components/ProposalBuilder/ProposalStream.tsx
+++ b/src/components/ProposalBuilder/ProposalStream.tsx
@@ -177,6 +177,7 @@ export function ProposalStream({
         >
           <BigIntInput
             value={stream.totalAmount.bigintValue}
+            parentFormikValue={stream.totalAmount}
             onChange={value => handleUpdateStream(index, { totalAmount: value })}
             decimalPlaces={tokenDecimals}
             maxValue={rawTokenBalance}
@@ -318,6 +319,7 @@ export function ProposalStream({
                                 <BigIntInput
                                   isRequired
                                   value={tranche.amount.bigintValue}
+                                  parentFormikValue={tranche.amount}
                                   decimalPlaces={tokenDecimals}
                                   placeholder="1000"
                                   onChange={value =>


### PR DESCRIPTION
### Summary

Stream deletion is pass to trigger update of `formikProps` outside `BigIntInput` component, which cause `value` prop and internal state `inputValue` to be un-synced.
State `inputValue` state was initialized with `value` and then managed by component logic, so we need to sync it with outside changes. And then I found there's a prop `parentFormikValue` designed for this purpose, so I just add this prop in `ProposalStream` and it works now.

### Related `BigIntInput` code

```typescript
/**
...
 * @param parentFormikValue This needs to be set to `values.yourFormValue` if the value of the Input control is changed outside of the component, for example via `setFieldValue`. This will update the value of the underlying Input control.
 */
export function BigIntInput({
  value,
  ...
  parentFormikValue = { value: '', bigintValue: undefined },
  ...rest
}: BigIntInputProps) {
  const [inputValue, setInputValue] = useState<string>(
    value && value !== 0n ? formatUnits(value, decimalPlaces) : '',
  );
  
  // if the parent Formik value prop changes, need to update the value
  useEffect(() => {
    // If parentFormikValue is set to undefined, then the input should be blank
    if (parentFormikValue === undefined) {
      setInputValue('');
      return;
    }

    // If parentFormikValue is the same as the input value, nothing needs to happen.
    if (inputValue === parentFormikValue.value) return;

    // If parentFormikValue does not match the input value (likely because it was set outside of the input's onChange handler),
    // then update the underlying input value so that the change is visible on the UI.
    // But if parentFormikValue.value is false-y, default to whatever is in the input.
    if (parentFormikValue.value !== inputValue) {
      setInputValue(parentFormikValue?.value || inputValue);
    }
  }, [parentFormikValue, inputValue]);
 
  ... 
}
```