### PR TITLE
`[ENG-342]` unable to remove a custom template

### DIFF
--- a/src/hooks/DAO/proposal/useCreateProposalTemplate.ts
+++ b/src/hooks/DAO/proposal/useCreateProposalTemplate.ts
@@ -8,17 +8,10 @@ import useIPFSClient from '../../../providers/App/hooks/useIPFSClient';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { ProposalExecuteData } from '../../../types';
 import { CreateProposalForm } from '../../../types/proposalBuilder';
+import { bigintSerializer } from '../../../utils/bigintSerializer';
 import { validateENSName } from '../../../utils/url';
 import { useNetworkEnsAddressAsync } from '../../useNetworkEnsAddress';
 import { useCurrentDAOKey } from '../useCurrentDAOKey';
-
-const customSerializer = (_: string, value: any) => {
-  if (typeof value === 'bigint') {
-    // need to convert bigint to string
-    return value.toString();
-  }
-  return value;
-};
 
 export default function useCreateProposalTemplate() {
   const { getEnsAddress } = useNetworkEnsAddressAsync();
@@ -68,7 +61,7 @@ export default function useCreateProposalTemplate() {
 
         const updatedTemplatesList = [...proposalTemplates, proposalTemplateData];
 
-        const { Hash } = await client.add(JSON.stringify(updatedTemplatesList, customSerializer));
+        const { Hash } = await client.add(JSON.stringify(updatedTemplatesList, bigintSerializer));
 
         const encodedUpdateValues = encodeFunctionData({
           abi: abis.KeyValuePairs,

--- a/src/hooks/DAO/proposal/useRemoveProposalTemplate.ts
+++ b/src/hooks/DAO/proposal/useRemoveProposalTemplate.ts
@@ -6,6 +6,7 @@ import { useStore } from '../../../providers/App/AppProvider';
 import useIPFSClient from '../../../providers/App/hooks/useIPFSClient';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { ProposalExecuteData } from '../../../types';
+import { bigintSerializer } from '../../../utils/bigintSerializer';
 import { useCurrentDAOKey } from '../useCurrentDAOKey';
 
 export default function useRemoveProposalTemplate() {
@@ -34,7 +35,7 @@ export default function useRemoveProposalTemplate() {
           (_, index: number) => index !== templateIndex,
         );
 
-        const { Hash } = await client.add(JSON.stringify(updatedTemplatesList));
+        const { Hash } = await client.add(JSON.stringify(updatedTemplatesList, bigintSerializer));
 
         const encodedUpdateValues = encodeFunctionData({
           abi: abis.KeyValuePairs,

--- a/src/utils/bigintSerializer.ts
+++ b/src/utils/bigintSerializer.ts
@@ -1,0 +1,7 @@
+export const bigintSerializer = (_: string, value: any) => {
+  if (typeof value === 'bigint') {
+    // need to convert bigint to string
+    return value.toString();
+  }
+  return value;
+};


### PR DESCRIPTION
### Summary

* Extract `bigintSerializer` from `useCreateProposalTemplate` to be shared/re-use.
* Add `bigintSerializer` to `useRemoveProposalTemplate -> json.stringify`, so it can properly handle the bigint.

### Error of this ticket

```javascript
Uncaught (in promise) TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at useRemoveProposalTemplate.ts:35:48
    at Object.onClick (ProposalTemplateCard.tsx:56:32)
    at OptionsList.tsx:19:14
```