### PR TITLE
`[ENG-547]` use number of unit(day/hour/minute) for duation

### DIFF
--- a/src/components/ProposalBuilder/ProposalStream.tsx
+++ b/src/components/ProposalBuilder/ProposalStream.tsx
@@ -23,10 +23,12 @@ import useNetworkPublicClient from '../../hooks/useNetworkPublicClient';
 import { useFilterSpamTokens } from '../../hooks/utils/useFilterSpamTokens';
 import { useStore } from '../../providers/App/AppProvider';
 import { useDaoInfoStore } from '../../store/daoInfo/useDaoInfoStore';
+import { BigIntValuePair } from '../../types';
 import { Stream } from '../../types/proposalBuilder';
 import { formatCoin } from '../../utils';
 import { scrollToBottom } from '../../utils/ui';
 import { BigIntInput } from '../ui/forms/BigIntInput';
+import DurationUnitStepperInput from '../ui/forms/DurationUnitStepperInput';
 import ExampleLabel from '../ui/forms/ExampleLabel';
 import { InputComponent, LabelComponent } from '../ui/forms/InputComponent';
 import { DisplayAddress } from '../ui/links/DisplayAddress';
@@ -353,22 +355,22 @@ export function ProposalStream({
                                   </VStack>
                                 }
                               >
-                                <BigIntInput
-                                  isRequired
-                                  value={tranche.duration.bigintValue}
-                                  placeholder={(SECONDS_IN_DAY * 365).toString()}
-                                  decimalPlaces={0}
-                                  min={index === 0 ? '1' : undefined}
-                                  step={1}
-                                  onChange={value =>
+                                <DurationUnitStepperInput
+                                  minSeconds={trancheIndex === 0 ? 1 : 0}
+                                  secondsValue={Number(tranche.duration.bigintValue || 0n)}
+                                  onSecondsValueChange={value => {
+                                    const duration: BigIntValuePair = {
+                                      bigintValue: BigInt(value),
+                                      value: value.toString(),
+                                    };
                                     handleUpdateStream(index, {
                                       tranches: stream.tranches.map((item, updatedTrancheIndex) =>
                                         updatedTrancheIndex === trancheIndex
-                                          ? { ...item, duration: value }
+                                          ? { ...item, duration }
                                           : item,
                                       ),
-                                    })
-                                  }
+                                    });
+                                  }}
                                 />
                               </LabelComponent>
                             </Box>

--- a/src/components/ProposalBuilder/constants.ts
+++ b/src/components/ProposalBuilder/constants.ts
@@ -23,6 +23,8 @@ export const DEFAULT_PROPOSAL = {
 };
 
 export const SECONDS_IN_DAY = 60 * 60 * 24;
+export const SECONDS_IN_HOUR = 60 * 60;
+export const SECONDS_IN_MINUTE = 60;
 
 export const DEFAULT_TRANCHE: Tranche = {
   amount: {

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -1,0 +1,102 @@
+import {
+  InputGroup,
+  Button,
+  HStack,
+  InputRightElement,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  Select,
+} from '@chakra-ui/react';
+import { Plus, Minus } from '@phosphor-icons/react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_HOUR,
+  SECONDS_IN_MINUTE,
+} from '../../ProposalBuilder/constants';
+
+interface DurationUnits {
+  unit: number;
+  label: string;
+}
+
+export default function DurationUnitStepperInput({
+  secondsValue,
+  onSecondsValueChange,
+  minSeconds = 0,
+}: {
+  secondsValue: number;
+  onSecondsValueChange: (val: number) => void;
+  minSeconds?: number;
+}) {
+  const { t } = useTranslation('common');
+
+  const units: DurationUnits[] = [
+    {
+      unit: SECONDS_IN_DAY,
+      label: t('days', { ns: 'common' }),
+    },
+    {
+      unit: SECONDS_IN_HOUR,
+      label: t('hours', { ns: 'common' }),
+    },
+    {
+      unit: SECONDS_IN_MINUTE,
+      label: t('minutes', { ns: 'common' }),
+    },
+  ];
+  const [selectedUnit, setSelectedUnit] = useState(units[0]);
+
+  const stepperButton = (direction: 'inc' | 'dec') => (
+    <Button
+      variant="secondary"
+      borderColor="neutral-3"
+      p="0.5rem"
+      size="md"
+    >
+      {direction === 'inc' ? <Plus size="1.5rem" /> : <Minus size="1.5rem" />}
+    </Button>
+  );
+
+  return (
+    <NumberInput
+      value={secondsValue / selectedUnit.unit}
+      onChange={val => onSecondsValueChange(Number(val) * selectedUnit.unit)}
+      min={minSeconds / selectedUnit.unit}
+      focusInputOnChange
+    >
+      <HStack gap="0.25rem">
+        <NumberDecrementStepper>{stepperButton('dec')}</NumberDecrementStepper>
+        <InputGroup>
+          <NumberInputField min={0} />
+          <InputRightElement minWidth="fit-content">
+            <Select
+              cursor="pointer"
+              border="none"
+              onChange={e => {
+                const unit = units.find(u => u.label === e.target.value);
+                if (unit) {
+                  setSelectedUnit(unit);
+                }
+              }}
+              value={selectedUnit.label}
+            >
+              {units.map((u, i) => (
+                <option
+                  key={i}
+                  value={u.label}
+                >
+                  {u.label}
+                </option>
+              ))}
+            </Select>
+          </InputRightElement>
+        </InputGroup>
+        <NumberIncrementStepper>{stepperButton('inc')}</NumberIncrementStepper>
+      </HStack>
+    </NumberInput>
+  );
+}

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -79,6 +79,12 @@ export default function DurationUnitStepperInput({
               onChange={e => {
                 const unit = units.find(u => u.label === e.target.value);
                 if (unit) {
+                  // Calculate ceiling value when changing to bigger unit
+                  //   , to avoid long decimals.
+                  if (unit.unit > selectedUnit.unit) {
+                    const ceil = Math.ceil(secondsValue / unit.unit);
+                    onSecondsValueChange(ceil * unit.unit);
+                  }
                   setSelectedUnit(unit);
                 }
               }}


### PR DESCRIPTION
### Summary

- new component `DurationUnitStepperInput` to accept input based on time units while returning seconds value
- replace `BigIntInput` with new component for "Tranche Duration"

### Screenshot

#### Duration input based on time unit
<img width="682" alt="image" src="https://github.com/user-attachments/assets/c03562d5-1c60-4c34-b7d8-bd4a1472c2bb" />

#### Preview duration is still based on seconds, no change
<img width="174" alt="image" src="https://github.com/user-attachments/assets/d3144c68-5dc9-4543-9c2e-92741e3a2409" />
