### PR TITLE
`[ENG-718]`: fix: Allow token fetching to fail gracefully and handle unknown values

### DIFF
--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -292,14 +292,16 @@ class EnhancedSafeApiKit {
           { address: tokenAddress, abi: erc20Abi, functionName: 'symbol' },
           { address: tokenAddress, abi: erc20Abi, functionName: 'decimals' },
         ],
-        allowFailure: false,
+        allowFailure: true,
       });
-
+      const resolvedName = name.result ?? 'Unknown Token';
+      const resolvedSymbol = symbol.result ?? 'Unknown Token';
+      const resolvedDecimals = decimals.result;
       return {
         address: tokenAddress,
-        name,
-        symbol,
-        decimals,
+        name: resolvedName,
+        symbol: resolvedSymbol,
+        decimals: Number(resolvedDecimals),
       };
     } catch (error) {
       console.error('Error fetching getToken from contract:', error);


### PR DESCRIPTION
This fixes the issues with the treasury page and the errors it was throwing. 