### PR TITLE
feat: Enhance proposal actions with metadata support

### DIFF
--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -1,11 +1,12 @@
 import { Button, Flex, Grid, Icon, Text, useDisclosure } from '@chakra-ui/react';
 import { ArrowsDownUp, Plus, PlusCircle, SquaresFour } from '@phosphor-icons/react';
+import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DETAILS_BOX_SHADOW } from '../../../constants/common';
 import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useStore } from '../../../providers/App/AppProvider';
 import { useProposalActionsStore } from '../../../store/actions/useProposalActionsStore';
-import { ProposalActionType } from '../../../types';
+import { CreateProposalForm, ProposalActionType } from '../../../types';
 import { prepareSendAssetsActionData } from '../../../utils/dao/prepareSendAssetsActionData';
 import { ModalBase } from './ModalBase';
 import { ModalType } from './ModalProvider';
@@ -77,13 +78,14 @@ export function AddActions() {
 
   const { t } = useTranslation(['actions', 'modals']);
   const { addAction } = useProposalActionsStore();
+  const { values } = useFormikContext<CreateProposalForm>();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsData => {
       const { action } = prepareSendAssetsActionData(sendAssetsData);
 
-      addAction({ ...action, content: <></> });
+      addAction({ ...action, proposalMetadata: values.proposalMetadata, content: <></> });
     },
     submitButtonText: t('Add Action', { ns: 'modals' }),
   });
@@ -94,6 +96,7 @@ export function AddActions() {
 
       addAction({
         actionType: actionType,
+        proposalMetadata: values.proposalMetadata,
         content: <></>,
         transactions: transactionBuilderData,
       });

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -31,10 +31,18 @@ export function SafeProposalWithActionsCreatePage() {
   const { safe } = useDaoInfoStore();
 
   const { prepareProposal } = usePrepareProposal();
-  const { getTransactions, actions } = useProposalActionsStore();
+  const { getTransactions, actions, proposalMetadata } = useProposalActionsStore();
   // getTransactions function depends on actions internally
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const transactions = useMemo(() => getTransactions(), [getTransactions, actions]);
+
+  const defaultProposalValues = proposalMetadata
+    ? {
+        ...DEFAULT_PROPOSAL,
+        proposalMetadata,
+      }
+    : DEFAULT_PROPOSAL;
+
   const { addressPrefix } = useNetworkConfigStore();
 
   const HEADER_HEIGHT = useHeaderHeight();
@@ -75,7 +83,7 @@ export function SafeProposalWithActionsCreatePage() {
   return (
     <ProposalBuilder
       initialValues={{
-        ...DEFAULT_PROPOSAL,
+        ...defaultProposalValues,
         transactions,
         nonce: safe.nextNonce,
       }}

--- a/src/store/actions/useProposalActionsStore.ts
+++ b/src/store/actions/useProposalActionsStore.ts
@@ -1,12 +1,17 @@
 import { create } from 'zustand';
-import { CreateProposalAction, CreateProposalTransaction } from '../../types';
+import {
+  CreateProposalAction,
+  CreateProposalMetadata,
+  CreateProposalTransaction,
+} from '../../types';
 
 interface ProposalActionsStoreData {
+  proposalMetadata?: CreateProposalMetadata;
   actions: CreateProposalAction[];
 }
 
 interface ProposalActionsStore extends ProposalActionsStoreData {
-  addAction: (action: CreateProposalAction) => void;
+  addAction: (action: CreateProposalAction & { proposalMetadata?: CreateProposalMetadata }) => void;
   removeAction: (actionIndex: number) => void;
   resetActions: () => void;
   getTransactions: () => CreateProposalTransaction[];
@@ -18,7 +23,12 @@ const initialProposalActionsStore: ProposalActionsStoreData = {
 
 export const useProposalActionsStore = create<ProposalActionsStore>()((set, get) => ({
   ...initialProposalActionsStore,
-  addAction: action => set(state => ({ actions: [...state.actions, action] })),
+  addAction: action =>
+    set(state => ({
+      ...state,
+      proposalMetadata: action.proposalMetadata,
+      actions: [...state.actions, action],
+    })),
   removeAction: actionIndex =>
     set(state => ({ actions: state.actions.filter((_, index) => index !== actionIndex) })),
   resetActions: () => set({ actions: [] }),


### PR DESCRIPTION
- src/store/actions/useProposalActionsStore.ts: Add proposalMetadata to actions store
- src/components/ui/modals/AddActions.tsx: Include proposalMetadata when adding actions
- src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx: Use proposalMetadata in default proposal values