### PR TITLE
Eng 720 set proposal details via actions store

### DIFF
--- a/src/components/ProposalBuilder/ProposalMetadata.tsx
+++ b/src/components/ProposalBuilder/ProposalMetadata.tsx
@@ -2,6 +2,7 @@ import { VStack } from '@chakra-ui/react';
 import { FormikProps } from 'formik';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
+import { useProposalActionsStore } from '../../store/actions/useProposalActionsStore';
 import { CreateProposalForm } from '../../types/proposalBuilder';
 import { InputComponent, TextareaComponent } from '../ui/forms/InputComponent';
 
@@ -40,7 +41,7 @@ export default function ProposalMetadata({
   typeProps,
 }: ProposalMetadataProps) {
   const { t } = useTranslation(['proposal']);
-
+  const { setProposalMetadata } = useProposalActionsStore();
   return (
     <VStack
       align="left"
@@ -53,7 +54,7 @@ export default function ProposalMetadata({
         placeholder={t('proposalTitlePlaceholder', { ns: 'proposal' })}
         isRequired
         value={proposalMetadata.title}
-        onChange={e => setFieldValue('proposalMetadata.title', e.target.value)}
+        onChange={e => setProposalMetadata({ ...proposalMetadata, title: e.target.value })}
         testId="metadata.title"
         maxLength={50}
       />
@@ -64,7 +65,7 @@ export default function ProposalMetadata({
         placeholder={t('proposalDescriptionPlaceholder', { ns: 'proposal' })}
         isRequired={false}
         value={proposalMetadata.description}
-        onChange={e => setFieldValue('proposalMetadata.description', e.target.value)}
+        onChange={e => setProposalMetadata({ ...proposalMetadata, description: e.target.value })}
         rows={12}
       />
       <InputComponent

--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -1,12 +1,11 @@
 import { Button, Flex, Grid, Icon, Text, useDisclosure } from '@chakra-ui/react';
 import { ArrowsDownUp, Plus, PlusCircle, SquaresFour } from '@phosphor-icons/react';
-import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { DETAILS_BOX_SHADOW } from '../../../constants/common';
 import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useStore } from '../../../providers/App/AppProvider';
 import { useProposalActionsStore } from '../../../store/actions/useProposalActionsStore';
-import { CreateProposalForm, ProposalActionType } from '../../../types';
+import { ProposalActionType } from '../../../types';
 import { prepareSendAssetsActionData } from '../../../utils/dao/prepareSendAssetsActionData';
 import { ModalBase } from './ModalBase';
 import { ModalType } from './ModalProvider';
@@ -78,14 +77,13 @@ export function AddActions() {
 
   const { t } = useTranslation(['actions', 'modals']);
   const { addAction } = useProposalActionsStore();
-  const { values } = useFormikContext<CreateProposalForm>();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsData => {
       const { action } = prepareSendAssetsActionData(sendAssetsData);
 
-      addAction({ ...action, proposalMetadata: values.proposalMetadata, content: <></> });
+      addAction({ ...action, content: <></> });
     },
     submitButtonText: t('Add Action', { ns: 'modals' }),
   });
@@ -96,7 +94,6 @@ export function AddActions() {
 
       addAction({
         actionType: actionType,
-        proposalMetadata: values.proposalMetadata,
         content: <></>,
         transactions: transactionBuilderData,
       });

--- a/src/store/actions/useProposalActionsStore.ts
+++ b/src/store/actions/useProposalActionsStore.ts
@@ -11,7 +11,8 @@ interface ProposalActionsStoreData {
 }
 
 interface ProposalActionsStore extends ProposalActionsStoreData {
-  addAction: (action: CreateProposalAction & { proposalMetadata?: CreateProposalMetadata }) => void;
+  addAction: (action: CreateProposalAction) => void;
+  setProposalMetadata: (proposalMetadata: CreateProposalMetadata) => void;
   removeAction: (actionIndex: number) => void;
   resetActions: () => void;
   getTransactions: () => CreateProposalTransaction[];
@@ -26,9 +27,9 @@ export const useProposalActionsStore = create<ProposalActionsStore>()((set, get)
   addAction: action =>
     set(state => ({
       ...state,
-      proposalMetadata: action.proposalMetadata,
       actions: [...state.actions, action],
     })),
+  setProposalMetadata: proposalMetadata => set({ proposalMetadata }),
   removeAction: actionIndex =>
     set(state => ({ actions: state.actions.filter((_, index) => index !== actionIndex) })),
   resetActions: () => set({ actions: [] }),

--- a/src/store/actions/useProposalActionsStore.ts
+++ b/src/store/actions/useProposalActionsStore.ts
@@ -32,7 +32,7 @@ export const useProposalActionsStore = create<ProposalActionsStore>()((set, get)
   setProposalMetadata: proposalMetadata => set({ proposalMetadata }),
   removeAction: actionIndex =>
     set(state => ({ actions: state.actions.filter((_, index) => index !== actionIndex) })),
-  resetActions: () => set({ actions: [] }),
+  resetActions: () => set({ actions: [], proposalMetadata: undefined }),
   getTransactions: () =>
     get()
       .actions.map(action => action.transactions)


### PR DESCRIPTION
This fixes the issue with proposal metadata. Just needed to lean a little further into the actions store. Now when we update the input fields it updates the action store, which then updates the form values boom.

Also fixes the issue when resetting the actions doesn't remove the metadata