### PR TITLE
fix(modal): prevent closing unsaved changes warning modal by overlay …

### DIFF
--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -254,6 +254,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
           modalContent = <ConfirmModifyGovernanceModal close={closeModal} />;
           break;
         case ModalType.WARN_UNSAVED_CHANGES:
+          closeModalOnOverlayClick = false;
           modalContent = (
             <UnsavedChangesWarningContent
               onDiscard={() => {


### PR DESCRIPTION
…click

Set closeModalOnOverlayClick to false for WARN_UNSAVED_CHANGES to ensure users do not accidentally dismiss the modal and lose unsaved changes.