### PR TITLE
`[ENG-726]` Refactor ProposalBuilder create button disabling logic

### DIFF
--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -183,16 +183,28 @@ export function ProposalBuilder({
         }
 
         const trimmedTitle = title.trim();
+        let createProposalButtonDisabled = false;
 
-        const noTransactionsOrStreams =
-          transactions.length === 0 &&
-          (formikProps.values as CreateSablierProposalForm).streams?.length === 0;
-        const createProposalButtonDisabled =
-          !canUserCreateProposal ||
+        // check sablier streams length if details are available
+        if (streamsDetails !== null) {
+          if ((formikProps.values as CreateSablierProposalForm).streams?.length === 0) {
+            createProposalButtonDisabled = true;
+          }
+        } else {
+          // otherwise check transactions length
+          if (transactions.length === 0) {
+            createProposalButtonDisabled = true;
+          }
+        }
+        // check form errors, title, description and pending create tx
+        if (
           Object.keys(formikProps.errors).length > 0 ||
           !trimmedTitle ||
-          noTransactionsOrStreams ||
-          pendingCreateTx;
+          !description ||
+          pendingCreateTx
+        ) {
+          createProposalButtonDisabled = true;
+        }
 
         const renderButtons = (step: CreateProposalSteps) => {
           const buttons = stepButtons({


### PR DESCRIPTION
- Reworked the logic for disabling the "Create Proposal" button in ProposalBuilder.
- Now explicitly checks for Sablier streams or transactions based on context.
- Consolidated all disabling conditions (form errors, empty title/description, pending tx) into a clear, stepwise sequence.
- Improves code clarity, maintainability, and prevents potential edge-case bugs.