### PR TITLE
`[ENG-642]` Filter spam ERC20 tokens

### DIFF
--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -16,6 +16,7 @@ import {
 import { formatCoin } from '../../../utils';
 import { CacheExpiry, CacheKeys } from '../../utils/cache/cacheDefaults';
 import { setValue } from '../../utils/cache/useLocalStorage';
+import { useFilterSpamTokens } from '../../utils/useFilterSpamTokens';
 import { useCurrentDAOKey } from '../useCurrentDAOKey';
 
 function getTransferEventType(transferFrom: string, safeAddress: Address | undefined) {
@@ -36,6 +37,10 @@ export const useDecentTreasury = () => {
     action,
     node: { safe },
   } = useStore({ daoKey });
+  const filterSpamTokens = useFilterSpamTokens({
+    includeNativeToken: true,
+    includeZeroBalanceToken: true,
+  });
   const safeAPI = useSafeAPI();
   const { getTokenBalances, getNFTBalances, getDeFiBalances } = useBalancesAPI();
 
@@ -99,7 +104,7 @@ export const useDecentTreasury = () => {
     if (defiBalancesError) {
       toast.warning(defiBalancesError, { duration: 2000 });
     }
-    const assetsFungible = tokenBalances || [];
+    const assetsFungible = filterSpamTokens(tokenBalances || []);
     const assetsNonFungible = nftBalances || [];
     const assetsDeFi = defiBalances || [];
 

--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -213,6 +213,7 @@ export const useDecentTreasury = () => {
     getTokenBalances,
     getNFTBalances,
     getDeFiBalances,
+    filterSpamTokens,
     action,
     chain.nativeCurrency.name,
     chain.nativeCurrency.symbol,

--- a/src/hooks/utils/useFilterSpamTokens.ts
+++ b/src/hooks/utils/useFilterSpamTokens.ts
@@ -39,8 +39,9 @@ export function useFilterSpamTokens(options: TokenListFilterOptions = {}) {
         const passSpamCheck = voteTokens.includes(asset.tokenAddress) || !asset.possibleSpam;
         const passNativeCheck = includeNativeToken || !asset.nativeToken;
         const passBalanceCheck = includeZeroBalanceToken || parseFloat(asset.balance) > 0;
+        const passAsciiNameCheck = Array.from(asset.symbol).every(char => char.charCodeAt(0) < 128);
 
-        return passSpamCheck && passBalanceCheck && passNativeCheck;
+        return passSpamCheck && passBalanceCheck && passNativeCheck && passAsciiNameCheck;
       });
     },
     [includeNativeToken, voteTokens, includeZeroBalanceToken],

--- a/src/hooks/utils/useFilterSpamTokens.ts
+++ b/src/hooks/utils/useFilterSpamTokens.ts
@@ -36,12 +36,15 @@ export function useFilterSpamTokens(options: TokenListFilterOptions = {}) {
   const tokenListFilter = useCallback(
     (tokens: TokenBalance[]) => {
       return tokens.filter(asset => {
-        const passSpamCheck = voteTokens.includes(asset.tokenAddress) || !asset.possibleSpam;
         const passNativeCheck = includeNativeToken || !asset.nativeToken;
         const passBalanceCheck = includeZeroBalanceToken || parseFloat(asset.balance) > 0;
-        const passAsciiNameCheck = Array.from(asset.symbol).every(char => char.charCodeAt(0) < 128);
 
-        return passSpamCheck && passBalanceCheck && passNativeCheck && passAsciiNameCheck;
+        const passSpamDetection = !asset.possibleSpam;
+        const passAsciiNameCheck = Array.from(asset.symbol).every(char => char.charCodeAt(0) < 128);
+        const passSpamCheck =
+          voteTokens.includes(asset.tokenAddress) || (passSpamDetection && passAsciiNameCheck);
+
+        return passSpamCheck && passBalanceCheck && passNativeCheck;
       });
     },
     [includeNativeToken, voteTokens, includeZeroBalanceToken],


### PR DESCRIPTION
### Changes

- Check if token symbol is using normal ASCII char, treat it as spam token if not
- Filter ERC20 tokens in `useDecentTreasury` loader, ensure the asset pass [Moralis spam detection](https://docs.moralis.com/web3-data-api/evm/spam-detection) and is using normal (`< 128`) ASCII char. (DAO's native governance token will always pass the check.)

### Screenshots: before vs now

#### Treasury page

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/a26f4186-4799-4dfb-9da0-dcbadfa77158" />

##### Treasury on Safe interface with [default token list](https://tokenlists.org/token-list?url=https://tokens.coingecko.com/uniswap/all.json)
<img width="231" alt="image" src="https://github.com/user-attachments/assets/237c1f53-828e-47f8-a6b8-6cc19a043a9f" />


#### Airdrop modal

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/e0cfada5-178e-4640-8dc1-412cecd2ce45" />
