### PR TITLE
`[ENG-802]` fix: Update proposer logic in useSafeTransactions hook

### DIFF
--- a/src/hooks/utils/useSafeTransactions.ts
+++ b/src/hooks/utils/useSafeTransactions.ts
@@ -156,7 +156,11 @@ export const useSafeTransactions = () => {
             proposalId: eventSafeTxHash,
             targets,
             // @dev proposer can be null when its the first transaction
-            proposer: isAddress(transaction.proposer) ? getAddress(transaction.proposer) : null,
+            proposer: isAddress(transaction.proposer)
+              ? getAddress(transaction.proposer)
+              : transaction.nonce === 0 && transaction.executor && isAddress(transaction.executor)
+                ? getAddress(transaction.executor)
+                : null,
             // @todo typing for `multiSigTransaction.transactionHash` is misleading, as ` multiSigTransaction.transactionHash` is not always defined (if ever). Need to tighten up the typing here.
             // ! @todo This is why we are showing the two different hashes
             transactionHash: transaction.transactionHash ?? transaction.safeTxHash,


### PR DESCRIPTION
The first proposal doesn't have a `proposer`. so for the proposals with nonce 0 we can use the `executor` to cover the spot. 

![image](https://github.com/user-attachments/assets/66b64d92-bc22-43b1-8341-cbe87de31a39)
