### PR TITLE
`[ENG-533]` [refactor]: simplify TxDetails by removing redundant InfoRows

### DIFF
--- a/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
@@ -40,14 +40,6 @@ export function TxDetails({ proposal }: { proposal: MultisigProposal }) {
           value={createAccountSubstring(proposal.proposalId)}
         />
         <InfoRow
-          property={t('txDetailsSignersCurrent')}
-          value={proposal.confirmations?.length.toString() || '0'}
-        />
-        <InfoRow
-          property={t('txDetailsSignersRequired')}
-          value={proposal.signersThreshold?.toString()}
-        />
-        <InfoRow
           property={t('created')}
           value={format(proposal.eventDate, DEFAULT_DATE_TIME_FORMAT)}
           tooltip={formatInTimeZone(proposal.eventDate, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
@@ -61,10 +53,6 @@ export function TxDetails({ proposal }: { proposal: MultisigProposal }) {
           property={t('transactionHash')}
           value={proposal.transactionHash ? undefined : '-'}
           txHash={proposal.transactionHash}
-        />
-        <InfoRow
-          property={t('nonce')}
-          value={proposal.nonce?.toString()}
         />
       </Box>
     </ContentBox>


### PR DESCRIPTION
- src/components/Proposals/MultisigProposalDetails/TxDetails.tsx:
  - Removed display of current signers count (`txDetailsSignersCurrent`)
  - Removed display of required signers threshold (`txDetailsSignersRequired`)
  - Removed display of proposal nonce (`nonce`)
  - Retained essential details: proposal ID, creation date, proposer, and transaction hash

This refactor streamlines the proposal transaction details view by focusing on the most relevant information and reducing visual clutter. In favor of #3010 

## Screenshot
![localhost_3000_proposals_0xe013fc4cc1730799799829272c524abe4b7cbf0f1996a5744c31606544f70f10_dao=sep_0x108951B78da9da2C9ED7Bc76E0Af73C0A67Db545(Desktop) (1)](https://github.com/user-attachments/assets/a8ac7b8a-7faf-4589-927f-11dfebe0a32e)
