### PR TITLE
`[ENG-809]` Add Conflicting Proposals section

### DIFF
--- a/public/locales/de/proposal.json
+++ b/public/locales/de/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Transaktion #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Neue Transaktion",
   "nonceLabelRecommendedTitle": "Empfohlene nonce",
-  "nonceLabelReplaceActiveTitle": "Ersetzen aktiv"
+  "nonceLabelReplaceActiveTitle": "Ersetzen aktiv",
+  "nonceLabelBannerActive": "{{confirmations}} von {{signersThreshold}} Unterzeichner wollen Nonce {{nonce}} ablehnen.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} wurde abgelehnt.",
+  "conflictingProposals": "Widersprüchliche Vorschläge",
+  "executableCode": "Ausführbarer Code"
 }

--- a/public/locales/en/proposal.json
+++ b/public/locales/en/proposal.json
@@ -205,5 +205,7 @@
   "nonceLabelRecommendedTitle": "Recommended nonce",
   "nonceLabelReplaceActiveTitle": "Replace active",
   "nonceLabelBannerActive": "{{confirmations}} of {{signersThreshold}} signers want to reject Nonce {{nonce}}.",
-  "nonceLabelBannerRejected": "Nonce {{nonce}} has been rejected."
+  "nonceLabelBannerRejected": "Nonce {{nonce}} has been rejected.",
+  "conflictingProposals": "Conflicting Proposals",
+  "executableCode": "Executable Code"
 }

--- a/public/locales/en/proposal.json
+++ b/public/locales/en/proposal.json
@@ -203,5 +203,7 @@
   "nonceLabelSingleTransaction": "Transaction #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - New Transaction",
   "nonceLabelRecommendedTitle": "Recommended nonce",
-  "nonceLabelReplaceActiveTitle": "Replace active"
+  "nonceLabelReplaceActiveTitle": "Replace active",
+  "nonceLabelBannerActive": "{{confirmations}} of {{signersThreshold}} signers want to reject Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} has been rejected."
 }

--- a/public/locales/es/proposal.json
+++ b/public/locales/es/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Transacción #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Nueva transacción",
   "nonceLabelRecommendedTitle": "Nonce recomendado",
-  "nonceLabelReplaceActiveTitle": "Sustituir activo"
+  "nonceLabelReplaceActiveTitle": "Sustituir activo",
+  "nonceLabelBannerActive": "{{confirmations}} de {{signersThreshold}} firmantes quieren rechazar Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} ha sido rechazado.",
+  "conflictingProposals": "Propuestas contradictorias",
+  "executableCode": "Código ejecutable"
 }

--- a/public/locales/fr/proposal.json
+++ b/public/locales/fr/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Transaction #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Nouvelle transaction",
   "nonceLabelRecommendedTitle": "Nonce recommandé",
-  "nonceLabelReplaceActiveTitle": "Remplacer les actifs"
+  "nonceLabelReplaceActiveTitle": "Remplacer les actifs",
+  "nonceLabelBannerActive": "{{confirmations}} des signataires {{signersThreshold}} veulent rejeter Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} a été rejeté.",
+  "conflictingProposals": "Propositions contradictoires",
+  "executableCode": "Code exécutable"
 }

--- a/public/locales/it/proposal.json
+++ b/public/locales/it/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Transazione #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Nuova transazione",
   "nonceLabelRecommendedTitle": "Nonce consigliato",
-  "nonceLabelReplaceActiveTitle": "Sostituire l'attivo"
+  "nonceLabelReplaceActiveTitle": "Sostituire l'attivo",
+  "nonceLabelBannerActive": "{{confirmations}} di {{signersThreshold}} firmatari vogliono rifiutare Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} è stato rifiutato.",
+  "conflictingProposals": "Proposte contrastanti",
+  "executableCode": "Codice eseguibile"
 }

--- a/public/locales/ja/proposal.json
+++ b/public/locales/ja/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "取引番号{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}}- 新規取引",
   "nonceLabelRecommendedTitle": "推奨ノンス",
-  "nonceLabelReplaceActiveTitle": "アクティブを置き換える"
+  "nonceLabelReplaceActiveTitle": "アクティブを置き換える",
+  "nonceLabelBannerActive": "{{confirmations} {{signersThreshold}}の署名者は、Nonce }を拒否したい。｝{{nonce}",
+  "nonceLabelBannerRejected": "Nonce{{nonce}} は拒否された。",
+  "conflictingProposals": "相反する提案",
+  "executableCode": "実行可能コード"
 }

--- a/public/locales/ko/proposal.json
+++ b/public/locales/ko/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "트랜잭션 #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - 새 거래",
   "nonceLabelRecommendedTitle": "권장 논스",
-  "nonceLabelReplaceActiveTitle": "활성 바꾸기"
+  "nonceLabelReplaceActiveTitle": "활성 바꾸기",
+  "nonceLabelBannerActive": "{{confirmations}의 서명자 중 {{signersThreshold}} 서명자가 Nonce {{nonce}}를 거부하려고 합니다.}",
+  "nonceLabelBannerRejected": "논스 {{nonce}}가 거부되었습니다.",
+  "conflictingProposals": "상충되는 제안",
+  "executableCode": "실행 코드"
 }

--- a/public/locales/pt/proposal.json
+++ b/public/locales/pt/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Transação #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Nova transação",
   "nonceLabelRecommendedTitle": "Nonce recomendado",
-  "nonceLabelReplaceActiveTitle": "Substituir ativo"
+  "nonceLabelReplaceActiveTitle": "Substituir ativo",
+  "nonceLabelBannerActive": "{{confirmations}} de {{signersThreshold}} signatários querem rejeitar Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} foi rejeitado.",
+  "conflictingProposals": "Propostas contraditórias",
+  "executableCode": "Código executável"
 }

--- a/public/locales/ru/proposal.json
+++ b/public/locales/ru/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Транзакция #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Новая транзакция",
   "nonceLabelRecommendedTitle": "Рекомендуемый нонс",
-  "nonceLabelReplaceActiveTitle": "Заменить активный"
+  "nonceLabelReplaceActiveTitle": "Заменить активный",
+  "nonceLabelBannerActive": "{{confirmations}Подписчики {{signersThreshold}} хотят отклонить Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} был отклонен.",
+  "conflictingProposals": "Противоречивые предложения",
+  "executableCode": "Исполняемый код"
 }

--- a/public/locales/uk/proposal.json
+++ b/public/locales/uk/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "Транзакція #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}} - Нова транзакція",
   "nonceLabelRecommendedTitle": "Рекомендований нонсенс",
-  "nonceLabelReplaceActiveTitle": "Замінити активний"
+  "nonceLabelReplaceActiveTitle": "Замінити активний",
+  "nonceLabelBannerActive": "{{confirmations}} підписантів {{signersThreshold}} хочуть відмовитися від Nonce {{nonce}}.",
+  "nonceLabelBannerRejected": "Nonce {{nonce}} було відхилено.",
+  "conflictingProposals": "Суперечливі пропозиції",
+  "executableCode": "Виконавчий код"
 }

--- a/public/locales/zh/proposal.json
+++ b/public/locales/zh/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "事务 #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}}- 新事务",
   "nonceLabelRecommendedTitle": "建议使用的 nonce",
-  "nonceLabelReplaceActiveTitle": "更换活动"
+  "nonceLabelReplaceActiveTitle": "更换活动",
+  "nonceLabelBannerActive": "{{confirmations} {{signersThreshold}} 的签名者希望拒绝接受 Nonce }。{{nonce}",
+  "nonceLabelBannerRejected": "Nonce{{nonce}} 已被拒绝。",
+  "conflictingProposals": "相互矛盾的建议",
+  "executableCode": "可执行代码"
 }

--- a/public/locales/zh_hant/proposal.json
+++ b/public/locales/zh_hant/proposal.json
@@ -203,5 +203,9 @@
   "nonceLabelSingleTransaction": "交易 #{{proposalId}}",
   "nonceLabelRecommended": "{{nonce}}- 新交易",
   "nonceLabelRecommendedTitle": "推薦的 nonce",
-  "nonceLabelReplaceActiveTitle": "取代作用中"
+  "nonceLabelReplaceActiveTitle": "取代作用中",
+  "nonceLabelBannerActive": "{{confirmations}的{{signersThreshold}} 簽署人想要拒絕 Nonce{{nonce}}。",
+  "nonceLabelBannerRejected": "Nonce{{nonce}} 已被拒絕。",
+  "conflictingProposals": "相互矛盾的提案",
+  "executableCode": "可執行程式碼"
 }

--- a/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
@@ -72,6 +72,7 @@ export function MultisigConflictingProposals({ proposal }: { proposal: MultisigP
   } = useDAOStore({ daoKey });
   const isMultisigProposal =
     type === GovernanceType.MULTISIG && !(proposal as SnapshotProposal)?.snapshotProposalId;
+  const { t } = useTranslation('proposal');
 
   if (!isMultisigProposal || !proposals || proposal.state === FractalProposalState.EXECUTED)
     return null;
@@ -99,7 +100,7 @@ export function MultisigConflictingProposals({ proposal }: { proposal: MultisigP
         my={4}
       />
       <AccordionDropdown
-        sectionTitle="Conflicting Proposals"
+        sectionTitle={t('conflictingProposals')}
         // @dev expands if there is a rejection proposal
         defaultExpandedIndecies={rejectionProposal ? [0] : undefined}
         contentCount={conflictingProposals.length}

--- a/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
@@ -102,7 +102,7 @@ export function MultisigConflictingProposals({ proposal }: { proposal: MultisigP
       <AccordionDropdown
         sectionTitle={t('conflictingProposals')}
         // @dev expands if there is a rejection proposal
-        defaultExpandedIndecies={rejectionProposal ? [0] : undefined}
+        defaultExpandedIndices={rejectionProposal ? [0] : undefined}
         contentCount={conflictingProposals.length}
         content={
           <Box mt={4}>

--- a/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
@@ -73,7 +73,8 @@ export function MultisigConflictingProposals({ proposal }: { proposal: MultisigP
   const isMultisigProposal =
     type === GovernanceType.MULTISIG && !(proposal as SnapshotProposal)?.snapshotProposalId;
 
-  if (!isMultisigProposal || !proposals) return null;
+  if (!isMultisigProposal || !proposals || proposal.state === FractalProposalState.EXECUTED)
+    return null;
   const multisigProposal = proposal as MultisigProposal;
   const proposalNonce = multisigProposal.nonce;
 

--- a/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
@@ -10,6 +10,7 @@ import {
   SnapshotProposal,
 } from '../../../types';
 import { AccordionDropdown } from '../../ui/containers/AccordionDropdown';
+import Divider from '../../ui/utils/Divider';
 import { SimpleProposalCard } from '../ProposalCard/SimpleProposalCard';
 
 function RejectionBanner({ rejectionProposal }: { rejectionProposal: MultisigProposal }) {
@@ -91,25 +92,31 @@ export function MultisigConflictingProposals({ proposal }: { proposal: MultisigP
   );
 
   return (
-    <AccordionDropdown
-      sectionTitle="Conflicting Proposals"
-      // @dev expands if there is a rejection proposal
-      defaultExpandedIndecies={rejectionProposal ? [0] : undefined}
-      contentCount={conflictingProposals.length}
-      content={
-        <Box mt={4}>
-          <NonceLabel nonce={proposalNonce} />
-          {rejectionProposal && <RejectionBanner rejectionProposal={rejectionProposal} />}
-          {conflictingProposalsOnlyNonRejections.map((p: MultisigProposal) => (
-            <Box
-              key={p.proposalId}
-              mb={2}
-            >
-              <SimpleProposalCard proposal={p} />
-            </Box>
-          ))}
-        </Box>
-      }
-    />
+    <>
+      <Divider
+        variant="dark"
+        my={4}
+      />
+      <AccordionDropdown
+        sectionTitle="Conflicting Proposals"
+        // @dev expands if there is a rejection proposal
+        defaultExpandedIndecies={rejectionProposal ? [0] : undefined}
+        contentCount={conflictingProposals.length}
+        content={
+          <Box mt={4}>
+            <NonceLabel nonce={proposalNonce} />
+            {rejectionProposal && <RejectionBanner rejectionProposal={rejectionProposal} />}
+            {conflictingProposalsOnlyNonRejections.map((p: MultisigProposal) => (
+              <Box
+                key={p.proposalId}
+                mb={2}
+              >
+                <SimpleProposalCard proposal={p} />
+              </Box>
+            ))}
+          </Box>
+        }
+      />
+    </>
   );
 }

--- a/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/MultisigConflictingProposals.tsx
@@ -1,0 +1,115 @@
+import { Box, Flex, Icon, Text } from '@chakra-ui/react';
+import { WarningCircle } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
+import { useDAOStore } from '../../../providers/App/AppProvider';
+import {
+  FractalProposalState,
+  GovernanceType,
+  MultisigProposal,
+  SnapshotProposal,
+} from '../../../types';
+import { AccordionDropdown } from '../../ui/containers/AccordionDropdown';
+import { SimpleProposalCard } from '../ProposalCard/SimpleProposalCard';
+
+function RejectionBanner({ rejectionProposal }: { rejectionProposal: MultisigProposal }) {
+  const { t } = useTranslation('proposal');
+  const activeRejectionLabel = t('nonceLabelBannerActive', {
+    confirmations: rejectionProposal.confirmations?.length,
+    signersThreshold: rejectionProposal.signersThreshold,
+    nonce: rejectionProposal.nonce,
+  });
+  const rejectedProposalLabel = t('nonceLabelBannerRejected', {
+    nonce: rejectionProposal.nonce,
+  });
+  return (
+    <Flex
+      mb={2}
+      alignItems="center"
+      gap={2}
+      p="1.5rem"
+      bg="red--2"
+      color="red-1"
+      border="1px solid"
+      borderColor="red--1"
+      borderRadius="0.75rem"
+    >
+      <Icon
+        as={WarningCircle}
+        boxSize={4}
+      />
+      <Text>
+        {rejectionProposal.state === FractalProposalState.EXECUTED
+          ? rejectedProposalLabel
+          : activeRejectionLabel}
+      </Text>
+    </Flex>
+  );
+}
+
+function NonceLabel({ nonce }: { nonce: number | undefined }) {
+  const { t } = useTranslation('proposal');
+
+  if (nonce === undefined) return null;
+  return (
+    <Text
+      mb={2}
+      textStyle="labels-large"
+      color="neutral-7"
+    >
+      {t('nonceLabel', {
+        number: nonce,
+      })}
+    </Text>
+  );
+}
+
+export function MultisigConflictingProposals({ proposal }: { proposal: MultisigProposal }) {
+  const { daoKey } = useCurrentDAOKey();
+  const {
+    governance: { proposals, type },
+  } = useDAOStore({ daoKey });
+  const isMultisigProposal =
+    type === GovernanceType.MULTISIG && !(proposal as SnapshotProposal)?.snapshotProposalId;
+
+  if (!isMultisigProposal || !proposals) return null;
+  const multisigProposal = proposal as MultisigProposal;
+  const proposalNonce = multisigProposal.nonce;
+
+  const conflictingProposals = proposals.filter(
+    (p: MultisigProposal) => p.nonce === proposalNonce && p.proposalId !== proposal.proposalId,
+  );
+
+  if (conflictingProposals.length === 0) return null;
+
+  const conflictingProposalsOnlyNonRejections = conflictingProposals.filter(
+    (p: MultisigProposal) => !p.isMultisigRejectionTx,
+  );
+
+  const rejectionProposal = conflictingProposals.find(
+    (p: MultisigProposal) => p.isMultisigRejectionTx,
+  );
+
+  return (
+    <AccordionDropdown
+      sectionTitle="Conflicting Proposals"
+      // @dev expands if there is a rejection proposal
+      defaultExpandedIndecies={rejectionProposal ? [0] : undefined}
+      contentCount={conflictingProposals.length}
+      content={
+        <Box mt={4}>
+          <NonceLabel nonce={proposalNonce} />
+          {rejectionProposal && <RejectionBanner rejectionProposal={rejectionProposal} />}
+          {conflictingProposalsOnlyNonRejections.map((p: MultisigProposal) => (
+            <Box
+              key={p.proposalId}
+              mb={2}
+            >
+              <SimpleProposalCard proposal={p} />
+            </Box>
+          ))}
+        </Box>
+      }
+    />
+  );
+}

--- a/src/components/Proposals/ProposalCard/SimpleProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard/SimpleProposalCard.tsx
@@ -1,0 +1,106 @@
+import { Box, Flex, Icon as ChakraIcon, Text, Spacer } from '@chakra-ui/react';
+import { CalendarBlank } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { Address } from 'viem';
+import { DAO_ROUTES } from '../../../constants/routes';
+import { useDateTimeDisplay } from '../../../helpers/dateTime';
+import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
+import { useNetworkEnsAvatar } from '../../../hooks/useNetworkEnsAvatar';
+import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
+import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
+import { FractalProposal, MultisigProposal } from '../../../types';
+import { ProposalTitle } from '../../Activity/ActivityDescriptionGovernance';
+import { SignerThresholdBadge } from '../../ui/badges/SignerThresholdBadge';
+import Avatar from '../../ui/page/Header/Avatar';
+
+function ProposalCreatedDate({ date }: { date: Date }) {
+  const createdDateLabel = useDateTimeDisplay(date);
+
+  return (
+    <Flex
+      gap="2"
+      alignItems="center"
+    >
+      <Text
+        textStyle="labels-small"
+        color="neutral-7"
+      >
+        {createdDateLabel}
+      </Text>
+      <ChakraIcon as={CalendarBlank} />
+    </Flex>
+  );
+}
+
+function ProposalCreatedBy({ createdBy }: { createdBy: Address }) {
+  const { t } = useTranslation('proposal');
+  const { displayName } = useGetAccountName(createdBy, true);
+  const { data: avatarURL } = useNetworkEnsAvatar({ name: displayName });
+  return (
+    <Flex
+      gap="2"
+      alignItems="center"
+    >
+      <Text
+        textStyle="labels-small"
+        color="neutral-7"
+      >
+        <Flex gap="1">
+          {t('by')}
+          <Avatar
+            size="sm"
+            address={createdBy}
+            url={avatarURL}
+          />
+          {displayName}
+        </Flex>
+      </Text>
+    </Flex>
+  );
+}
+
+export function SimpleProposalCard({ proposal }: { proposal: FractalProposal }) {
+  const { safeAddress } = useCurrentDAOKey();
+  const { addressPrefix } = useNetworkConfigStore();
+
+  if (!safeAddress) {
+    return null;
+  }
+
+  return (
+    <Link to={DAO_ROUTES.proposal.relative(addressPrefix, safeAddress, proposal.proposalId)}>
+      <Box
+        minHeight="6.25rem"
+        bg="neutral-3"
+        _hover={{ bg: 'neutral-4' }}
+        _active={{ bg: 'neutral-4', border: '1px solid', borderColor: 'neutral-4' }}
+        transition="all ease-out 300ms"
+        p="1.5rem"
+        borderRadius="0.75rem"
+      >
+        {/* Top Row */}
+        <Flex
+          justifyContent="space-between"
+          flexWrap="wrap"
+          gap="1rem"
+        >
+          <ProposalTitle activity={proposal} />
+          <SignerThresholdBadge
+            numberOfConfirmedSigners={(proposal as MultisigProposal).confirmations?.length}
+            proposalThreshold={(proposal as MultisigProposal).signersThreshold}
+          />
+        </Flex>
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          mt={4}
+        >
+          {proposal.proposer && <ProposalCreatedBy createdBy={proposal.proposer} />}
+          <Spacer />
+          {proposal.eventDate && <ProposalCreatedDate date={proposal.eventDate} />}
+        </Flex>
+      </Box>
+    </Link>
+  );
+}

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -17,6 +17,8 @@ import { useDecentModal } from '../ui/modals/useDecentModal';
 import { ProposalCountdown } from '../ui/proposal/ProposalCountdown';
 import ProposalExecutableCode from '../ui/proposal/ProposalExecutableCode';
 import CeleryButtonWithIcon from '../ui/utils/CeleryButtonWithIcon';
+import Divider from '../ui/utils/Divider';
+import { MultisigConflictingProposals } from './MultisigProposalDetails/MultisigConflictingProposals';
 
 export function ProposalInfo({
   proposal,
@@ -130,6 +132,11 @@ export function ProposalInfo({
           />
         )}
         <ProposalExecutableCode proposal={proposal} />
+        <Divider
+          variant="dark"
+          my={4}
+        />
+        <MultisigConflictingProposals proposal={proposal} />
       </Box>
     </Box>
   );

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -17,7 +17,6 @@ import { useDecentModal } from '../ui/modals/useDecentModal';
 import { ProposalCountdown } from '../ui/proposal/ProposalCountdown';
 import ProposalExecutableCode from '../ui/proposal/ProposalExecutableCode';
 import CeleryButtonWithIcon from '../ui/utils/CeleryButtonWithIcon';
-import Divider from '../ui/utils/Divider';
 import { MultisigConflictingProposals } from './MultisigProposalDetails/MultisigConflictingProposals';
 
 export function ProposalInfo({
@@ -132,10 +131,6 @@ export function ProposalInfo({
           />
         )}
         <ProposalExecutableCode proposal={proposal} />
-        <Divider
-          variant="dark"
-          my={4}
-        />
         <MultisigConflictingProposals proposal={proposal} />
       </Box>
     </Box>

--- a/src/components/ui/containers/AccordionDropdown.tsx
+++ b/src/components/ui/containers/AccordionDropdown.tsx
@@ -32,12 +32,12 @@ export function AccordionDropdown({
   content,
   contentCount,
   sectionTitle,
-  defaultExpandedIndecies,
+  defaultExpandedIndices,
 }: {
   content: React.ReactNode;
   contentCount?: number;
   sectionTitle: string;
-  defaultExpandedIndecies?: number[];
+  defaultExpandedIndices?: number[];
 }) {
   return (
     <Box
@@ -51,7 +51,7 @@ export function AccordionDropdown({
       <Accordion
         allowToggle
         gap="1.5rem"
-        defaultIndex={defaultExpandedIndecies}
+        defaultIndex={defaultExpandedIndices}
       >
         <AccordionItem
           borderTop="none"

--- a/src/components/ui/containers/AccordionDropdown.tsx
+++ b/src/components/ui/containers/AccordionDropdown.tsx
@@ -1,0 +1,95 @@
+import {
+  Box,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+  Flex,
+} from '@chakra-ui/react';
+
+function ContentCountBadge({ count }: { count: number | undefined }) {
+  if (!count) {
+    return null;
+  }
+  return (
+    <Box
+      textStyle="labels-small"
+      rounded="9999px"
+      bg="celery--2"
+      border="1px solid"
+      borderColor="celery--5"
+      color="celery--6"
+      boxSize="1.25rem"
+      textAlign="center"
+    >
+      {count}
+    </Box>
+  );
+}
+
+export function AccordionDropdown({
+  content,
+  contentCount,
+  sectionTitle,
+  defaultExpandedIndecies,
+}: {
+  content: React.ReactNode;
+  contentCount?: number;
+  sectionTitle: string;
+  defaultExpandedIndecies?: number[];
+}) {
+  return (
+    <Box
+      marginTop={4}
+      padding="1rem"
+      borderRadius="0.75rem"
+      bg="neutral-2"
+      border="1px solid"
+      borderColor="neutral-3"
+    >
+      <Accordion
+        allowToggle
+        gap="1.5rem"
+        defaultIndex={defaultExpandedIndecies}
+      >
+        <AccordionItem
+          borderTop="none"
+          borderBottom="none"
+        >
+          {({ isExpanded }) => (
+            <>
+              <Flex
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <AccordionButton
+                  p={0}
+                  textStyle="heading-small"
+                  color="lilac-0"
+                >
+                  <Flex alignItems="center">
+                    <AccordionIcon
+                      marginRight={3}
+                      transform={`rotate(-${isExpanded ? '0' : '90'}deg)`}
+                    />
+                    {sectionTitle}
+                  </Flex>
+                </AccordionButton>
+                <ContentCountBadge count={contentCount} />
+              </Flex>
+              <AccordionPanel paddingBottom={4}>
+                <Flex
+                  gap={2}
+                  flexDirection="column"
+                >
+                  {content}
+                </Flex>
+              </AccordionPanel>
+            </>
+          )}
+        </AccordionItem>
+      </Accordion>
+    </Box>
+  );
+}

--- a/src/components/ui/proposal/ProposalExecutableCode.tsx
+++ b/src/components/ui/proposal/ProposalExecutableCode.tsx
@@ -133,12 +133,13 @@ function TransactionBlock({ transaction }: { transaction: DecodedTransaction }) 
 }
 
 export default function ProposalExecutableCode({ proposal }: { proposal: FractalProposal }) {
+  const { t } = useTranslation('proposal');
   if (!proposal.data) {
     return null;
   }
   return (
     <AccordionDropdown
-      sectionTitle="Executable Code"
+      sectionTitle={t('executableCode')}
       content={
         <Flex
           mt={2}

--- a/src/components/ui/proposal/ProposalExecutableCode.tsx
+++ b/src/components/ui/proposal/ProposalExecutableCode.tsx
@@ -1,20 +1,10 @@
-import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Alert,
-  AlertTitle,
-  Box,
-  Flex,
-  Text,
-} from '@chakra-ui/react';
+import { Alert, AlertTitle, Box, Flex, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { isAddress } from 'viem';
 import { Info } from '../../../assets/theme/custom/icons/Info';
 import { ADDRESS_MULTISIG_METADATA } from '../../../constants/common';
 import { DecodedTransaction, FractalProposal } from '../../../types';
+import { AccordionDropdown } from '../containers/AccordionDropdown';
 import EtherscanLink from '../links/EtherscanLink';
 
 function TransactionRow({ paramKey, value }: { paramKey: string; value: string }) {
@@ -143,57 +133,26 @@ function TransactionBlock({ transaction }: { transaction: DecodedTransaction }) 
 }
 
 export default function ProposalExecutableCode({ proposal }: { proposal: FractalProposal }) {
-  const { t } = useTranslation('proposal');
   if (!proposal.data) {
     return null;
   }
   return (
-    <Box
-      marginTop={4}
-      padding="1.5rem"
-      borderRadius="0.75rem"
-      bg="neutral-2"
-      border="1px solid"
-      borderColor="neutral-3"
-    >
-      <Accordion
-        allowToggle
-        gap="1.5rem"
-      >
-        <AccordionItem
-          borderTop="none"
-          borderBottom="none"
+    <AccordionDropdown
+      sectionTitle="Executable Code"
+      content={
+        <Flex
+          mt={2}
+          gap={2}
+          flexDirection="column"
         >
-          {({ isExpanded }) => (
-            <>
-              <AccordionButton
-                p={0}
-                textStyle="heading-small"
-                color="lilac-0"
-              >
-                <AccordionIcon
-                  marginRight={3}
-                  transform={`rotate(-${isExpanded ? '0' : '90'}deg)`}
-                />
-                {t(isExpanded ? 'hideExecutableCode' : 'showExecutableCode')}
-              </AccordionButton>
-              <AccordionPanel paddingBottom={4}>
-                <Flex
-                  gap={2}
-                  flexDirection="column"
-                >
-                  {proposal.data?.decodedTransactions.map((tx, i) => (
-                    <TransactionBlock
-                      transaction={tx}
-                      key={i}
-                    />
-                  ))}
-                </Flex>
-              </AccordionPanel>
-            </>
-          )}
-        </AccordionItem>
-      </Accordion>
-    </Box>
+          {proposal.data?.decodedTransactions.map((tx, i) => (
+            <TransactionBlock
+              transaction={tx}
+              key={i}
+            />
+          ))}
+        </Flex>
+      }
+    />
   );
 }


### PR DESCRIPTION
Actual changed files: **6**
## Changes
- Extracted out UI `AccordianDropdown` component code from `ProposalExecutionCode` component for reuse
- Update AccordianDropdown with smaller padding
- Added new section 'Conflictiing Proposals` for multisig type proposals
- Update copy files

## Covered edge cases
- When there are no conflicting proposal section isn't shown
- When a nonce has been rejected a different banner is shown
- When the viewing proposal has been executed conflicting proposal section is hidden

## Screenshots
![localhost_3000_home_dao=sep%3A0x6F0D15767671ca64165547f2588104Bd7052c70D page=1 size=10(Desktop) (3)](https://github.com/user-attachments/assets/33e89c36-d377-4194-ab39-5ce272ee76cc)
![localhost_3000_home_dao=sep%3A0x6F0D15767671ca64165547f2588104Bd7052c70D page=1 size=10(Desktop) (2)](https://github.com/user-attachments/assets/d6ffb5c2-7ceb-43f2-93cf-148476d74798)
![localhost_3000_home_dao=sep%3A0x6F0D15767671ca64165547f2588104Bd7052c70D page=1 size=10(Desktop) (1)](https://github.com/user-attachments/assets/a5835f6f-b679-41b0-84a7-cc72c1428d20)
![localhost_3000_home_dao=sep%3A0x6F0D15767671ca64165547f2588104Bd7052c70D page=1 size=10(Desktop)](https://github.com/user-attachments/assets/9d0a67a6-12c1-4c0c-a5a5-87738a5a1a9c)
