### PR TITLE
`[ENG-846]` Add confirmation modals

### DIFF
--- a/public/locales/de/proposal.json
+++ b/public/locales/de/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} von {{signersThreshold}} Unterzeichner wollen Nonce {{nonce}} ablehnen.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} wurde abgelehnt.",
   "conflictingProposals": "Widersprüchliche Vorschläge",
-  "executableCode": "Ausführbarer Code"
+  "executableCode": "Ausführbarer Code",
+  "confirmRejectProposal": "Vorschlag ablehnen?",
+  "rejectProposalYesRejectIt": "Ja, lehnen Sie es ab",
+  "rejectProposalDescription": "Wenn genügend Unterzeichner diesen oder einen anderen Vorschlag mit der gleichen Nonce ablehnen, wird auch die Option zur Ablehnung aller zugehörigen Vorschläge verfügbar.",
+  "rejectProposalNevermind": "Vergessen Sie",
+  "rejectProposalAreYouSure": "Sind Sie sicher, dass Sie diesen Vorschlag ablehnen wollen?",
+  "rejectProposalAreYouSureDescription": "Bitte beachten Sie: Diese Aktion ist unumkehrbar.",
+  "confirmExecution": "Bestätigen Sie die Ausführung",
+  "executionDescription": "Sie führen nur diesen Vorschlag aus. Alle anderen Vorschläge mit <color>Nonce {{nonce}</color> } werden automatisch abgelehnt."
 }

--- a/public/locales/en/proposal.json
+++ b/public/locales/en/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} of {{signersThreshold}} signers want to reject Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} has been rejected.",
   "conflictingProposals": "Conflicting Proposals",
-  "executableCode": "Executable Code"
+  "executableCode": "Executable Code",
+  "confirmRejectProposal": "Reject Proposal?",
+  "rejectProposalYesRejectIt": "Yes, Reject it",
+  "rejectProposalDescription": "If enough signers Reject this or any proposal with the same Nonce, the option to Reject all related proposal will also become available.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Are you sure you want to reject this proposal?",
+  "rejectProposalAreYouSureDescription": "Please note: This action is irreversible.",
+  "confirmExecution": "Confirm Execution",
+  "executionDescription": "You are executing this proposal only. All other proposals with <color>Nonce {{nonce}}</color> will automatically be rejected."
 }

--- a/public/locales/es/proposal.json
+++ b/public/locales/es/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} de {{signersThreshold}} firmantes quieren rechazar Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} ha sido rechazado.",
   "conflictingProposals": "Propuestas contradictorias",
-  "executableCode": "Código ejecutable"
+  "executableCode": "Código ejecutable",
+  "confirmRejectProposal": "¿Rechazar la propuesta?",
+  "rejectProposalYesRejectIt": "Sí, recházalo",
+  "rejectProposalDescription": "Si un número suficiente de firmantes rechaza esta propuesta o cualquier otra con el mismo nonce, también estará disponible la opción de rechazar todas las propuestas relacionadas.",
+  "rejectProposalNevermind": "No importa",
+  "rejectProposalAreYouSure": "¿Está seguro de que quiere rechazar esta propuesta?",
+  "rejectProposalAreYouSureDescription": "Nota: Esta acción es irreversible.",
+  "confirmExecution": "Confirmar ejecución",
+  "executionDescription": "Sólo está ejecutando esta propuesta. Todas las demás propuestas con <color>Nonce {{nonce}</color> } serán rechazadas automáticamente."
 }

--- a/public/locales/fr/proposal.json
+++ b/public/locales/fr/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} des signataires {{signersThreshold}} veulent rejeter Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} a été rejeté.",
   "conflictingProposals": "Propositions contradictoires",
-  "executableCode": "Code exécutable"
+  "executableCode": "Code exécutable",
+  "confirmRejectProposal": "Rejeter la proposition ?",
+  "rejectProposalYesRejectIt": "Oui, rejeter",
+  "rejectProposalDescription": "Si un nombre suffisant de signataires rejettent cette proposition ou toute autre proposition avec le même Nonce, l'option de rejeter toutes les propositions correspondantes sera également disponible.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Êtes-vous sûr de vouloir rejeter cette proposition ?",
+  "rejectProposalAreYouSureDescription": "Remarque : cette action est irréversible.",
+  "confirmExecution": "Confirmer l'exécution",
+  "executionDescription": "Vous n'exécutez que cette proposition. Toutes les autres propositions avec <color>Nonce {{nonce}</color> } seront automatiquement rejetées."
 }

--- a/public/locales/it/proposal.json
+++ b/public/locales/it/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} di {{signersThreshold}} firmatari vogliono rifiutare Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} è stato rifiutato.",
   "conflictingProposals": "Proposte contrastanti",
-  "executableCode": "Codice eseguibile"
+  "executableCode": "Codice eseguibile",
+  "confirmRejectProposal": "Rifiutare la proposta?",
+  "rejectProposalYesRejectIt": "Sì, rifiutare",
+  "rejectProposalDescription": "Se un numero sufficiente di firmatari rifiuta questa o qualsiasi proposta con lo stesso Nonce, diventa disponibile anche l'opzione di rifiutare tutte le proposte correlate.",
+  "rejectProposalNevermind": "Non importa",
+  "rejectProposalAreYouSure": "Siete sicuri di voler rifiutare questa proposta?",
+  "rejectProposalAreYouSureDescription": "Nota bene: questa azione è irreversibile.",
+  "confirmExecution": "Confermare l'esecuzione",
+  "executionDescription": "Si sta eseguendo solo questa proposta. Tutte le altre proposte con <color>Nonce {{nonce}</color> } saranno automaticamente rifiutate."
 }

--- a/public/locales/ja/proposal.json
+++ b/public/locales/ja/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations} {{signersThreshold}}の署名者は、Nonce }を拒否したい。｝{{nonce}",
   "nonceLabelBannerRejected": "Nonce{{nonce}} は拒否された。",
   "conflictingProposals": "相反する提案",
-  "executableCode": "実行可能コード"
+  "executableCode": "実行可能コード",
+  "confirmRejectProposal": "プロポーズを断る？",
+  "rejectProposalYesRejectIt": "はい、拒否します",
+  "rejectProposalDescription": "十分な数の署名者がこの提案、あるいは同じNonceを持つ提案を拒否した場合、関連するすべての提案を拒否するオプションも利用可能になります。",
+  "rejectProposalNevermind": "ネバーマインド",
+  "rejectProposalAreYouSure": "本当にこの提案を拒否したいのか？",
+  "rejectProposalAreYouSureDescription": "注意：この処置は不可逆的です。",
+  "confirmExecution": "実行の確認",
+  "executionDescription": "このプロポーザルのみを実行します。<color>Nonce{{nonce}</color>}を含む他の提案はすべて自動的に却下されます。"
 }

--- a/public/locales/ko/proposal.json
+++ b/public/locales/ko/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}의 서명자 중 {{signersThreshold}} 서명자가 Nonce {{nonce}}를 거부하려고 합니다.}",
   "nonceLabelBannerRejected": "논스 {{nonce}}가 거부되었습니다.",
   "conflictingProposals": "상충되는 제안",
-  "executableCode": "실행 코드"
+  "executableCode": "실행 코드",
+  "confirmRejectProposal": "제안을 거부하시겠습니까?",
+  "rejectProposalYesRejectIt": "예, 거부",
+  "rejectProposalDescription": "충분한 서명자가 이 제안 또는 동일한 논스를 가진 제안을 거부하면 관련된 모든 제안을 거부하는 옵션도 사용할 수 있게 됩니다.",
+  "rejectProposalNevermind": "네버마인드",
+  "rejectProposalAreYouSure": "이 제안을 거부하시겠습니까?",
+  "rejectProposalAreYouSureDescription": "참고: 이 작업은 되돌릴 수 없습니다.",
+  "confirmExecution": "실행 확인",
+  "executionDescription": "이 제안만 실행 중입니다. <color>Nonce {{nonce}</color> }가 포함된 다른 모든 제안은 자동으로 거부됩니다."
 }

--- a/public/locales/pt/proposal.json
+++ b/public/locales/pt/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} de {{signersThreshold}} signatários querem rejeitar Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} foi rejeitado.",
   "conflictingProposals": "Propostas contraditórias",
-  "executableCode": "Código executável"
+  "executableCode": "Código executável",
+  "confirmRejectProposal": "Rejeitar a proposta?",
+  "rejectProposalYesRejectIt": "Sim, Rejeitar",
+  "rejectProposalDescription": "Se um número suficiente de signatários rejeitar esta ou qualquer proposta com o mesmo Nonce, a opção de Rejeitar todas as propostas relacionadas também ficará disponível.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Têm a certeza de que querem rejeitar esta proposta?",
+  "rejectProposalAreYouSureDescription": "Atenção: esta ação é irreversível.",
+  "confirmExecution": "Confirmar a execução",
+  "executionDescription": "Só está a executar esta proposta. Todas as outras propostas com <color>Nonce {{nonce}</color> } serão automaticamente rejeitadas."
 }

--- a/public/locales/ru/proposal.json
+++ b/public/locales/ru/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}Подписчики {{signersThreshold}} хотят отклонить Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} был отклонен.",
   "conflictingProposals": "Противоречивые предложения",
-  "executableCode": "Исполняемый код"
+  "executableCode": "Исполняемый код",
+  "confirmRejectProposal": "Отклонить предложение?",
+  "rejectProposalYesRejectIt": "Да, отклонить",
+  "rejectProposalDescription": "Если достаточное количество подписантов отклонит это или любое другое предложение с тем же Nonce, станет доступна опция отклонить все связанные предложения.",
+  "rejectProposalNevermind": "Неважно",
+  "rejectProposalAreYouSure": "Вы уверены, что хотите отклонить это предложение?",
+  "rejectProposalAreYouSureDescription": "Обратите внимание: это действие необратимо.",
+  "confirmExecution": "Подтвердить выполнение",
+  "executionDescription": "You are executing this proposal only. All other proposals with <color>Nonce {{nonce}}</color> will automatically be rejected."
 }

--- a/public/locales/uk/proposal.json
+++ b/public/locales/uk/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}} підписантів {{signersThreshold}} хочуть відмовитися від Nonce {{nonce}}.",
   "nonceLabelBannerRejected": "Nonce {{nonce}} було відхилено.",
   "conflictingProposals": "Суперечливі пропозиції",
-  "executableCode": "Виконавчий код"
+  "executableCode": "Виконавчий код",
+  "confirmRejectProposal": "Reject Proposal?",
+  "rejectProposalYesRejectIt": "Yes, Reject it",
+  "rejectProposalDescription": "If enough signers Reject this or any proposal with the same Nonce, the option to Reject all related proposal will also become available.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Are you sure you want to reject this proposal?",
+  "rejectProposalAreYouSureDescription": "Please note: This action is irreversible.",
+  "confirmExecution": "Confirm Execution",
+  "executionDescription": "You are executing this proposal only. All other proposals with <color>Nonce {{nonce}}</color> will automatically be rejected."
 }

--- a/public/locales/zh/proposal.json
+++ b/public/locales/zh/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations} {{signersThreshold}} 的签名者希望拒绝接受 Nonce }。{{nonce}",
   "nonceLabelBannerRejected": "Nonce{{nonce}} 已被拒绝。",
   "conflictingProposals": "相互矛盾的建议",
-  "executableCode": "可执行代码"
+  "executableCode": "可执行代码",
+  "confirmRejectProposal": "Reject Proposal?",
+  "rejectProposalYesRejectIt": "Yes, Reject it",
+  "rejectProposalDescription": "If enough signers Reject this or any proposal with the same Nonce, the option to Reject all related proposal will also become available.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Are you sure you want to reject this proposal?",
+  "rejectProposalAreYouSureDescription": "Please note: This action is irreversible.",
+  "confirmExecution": "Confirm Execution",
+  "executionDescription": "You are executing this proposal only. All other proposals with <color>Nonce {{nonce}}</color> will automatically be rejected."
 }

--- a/public/locales/zh_hant/proposal.json
+++ b/public/locales/zh_hant/proposal.json
@@ -215,5 +215,13 @@
   "nonceLabelBannerActive": "{{confirmations}的{{signersThreshold}} 簽署人想要拒絕 Nonce{{nonce}}。",
   "nonceLabelBannerRejected": "Nonce{{nonce}} 已被拒絕。",
   "conflictingProposals": "相互矛盾的提案",
-  "executableCode": "可執行程式碼"
+  "executableCode": "可執行程式碼",
+  "confirmRejectProposal": "Reject Proposal?",
+  "rejectProposalYesRejectIt": "Yes, Reject it",
+  "rejectProposalDescription": "If enough signers Reject this or any proposal with the same Nonce, the option to Reject all related proposal will also become available.",
+  "rejectProposalNevermind": "Nevermind",
+  "rejectProposalAreYouSure": "Are you sure you want to reject this proposal?",
+  "rejectProposalAreYouSureDescription": "Please note: This action is irreversible.",
+  "confirmExecution": "Confirm Execution",
+  "executionDescription": "You are executing this proposal only. All other proposals with <color>Nonce {{nonce}}</color> will automatically be rejected."
 }

--- a/src/components/Proposals/MultisigProposalDetails/ExectionSection.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/ExectionSection.tsx
@@ -17,15 +17,20 @@ import { useDAOStore } from '../../../providers/App/AppProvider';
 import { FractalProposalState, MultisigProposal } from '../../../types';
 import { DecentTooltip } from '../../ui/DecentTooltip';
 import { SectionBottomContentBox } from '../../ui/containers/ContentBox';
+import { ModalType } from '../../ui/modals/ModalProvider';
+import { useDecentModal } from '../../ui/modals/useDecentModal';
 
 function useProposalExecutionButtonAction(
   state: FractalProposalState | null | undefined,
   proposalTransaction: SafeMultisigTransactionResponse | undefined,
+  proposalId: string | undefined,
+  proposalNonce: number | undefined,
   requireDataHex: boolean,
 ) {
   const { daoKey } = useCurrentDAOKey();
   const {
     guardContracts: { freezeGuardContractAddress },
+    governance: { proposals },
     node: { safe },
   } = useDAOStore({ daoKey });
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
@@ -34,7 +39,11 @@ function useProposalExecutionButtonAction(
   const { loadSafeMultisigProposals } = useSafeMultisigProposals();
   const { t } = useTranslation(['transaction']);
 
-  if (!state || !walletClient) return { action: undefined, actionPending: false };
+  const conflictingProposals =
+    proposals?.filter(
+      (p: MultisigProposal) =>
+        p.nonce === proposalNonce && p.proposalId !== proposalId && !p.isMultisigRejectionTx,
+    ) ?? [];
 
   const timelockTransaction = async () => {
     try {
@@ -180,6 +189,18 @@ function useProposalExecutionButtonAction(
     }
   };
 
+  const openExecutionConfirmModal = useDecentModal(ModalType.CONFIRM_EXECUTION, {
+    nonce: proposalNonce,
+    submitExecution: () =>
+      executeMultisigProposal({
+        messages: {
+          failed: t('failedExecute', { ns: 'transaction' }),
+          pending: t('pendingExecute', { ns: 'transaction' }),
+          success: t('successExecute', { ns: 'transaction' }),
+        },
+      }),
+  });
+
   switch (state) {
     case FractalProposalState.ACTIVE:
       return {
@@ -188,14 +209,17 @@ function useProposalExecutionButtonAction(
       };
     case FractalProposalState.EXECUTABLE:
       return {
-        action: () =>
-          executeMultisigProposal({
-            messages: {
-              failed: t('failedExecute', { ns: 'transaction' }),
-              pending: t('pendingExecute', { ns: 'transaction' }),
-              success: t('successExecute', { ns: 'transaction' }),
-            },
-          }),
+        action:
+          conflictingProposals.length > 0
+            ? openExecutionConfirmModal
+            : () =>
+                executeMultisigProposal({
+                  messages: {
+                    failed: t('failedExecute', { ns: 'transaction' }),
+                    pending: t('pendingExecute', { ns: 'transaction' }),
+                    success: t('successExecute', { ns: 'transaction' }),
+                  },
+                }),
         actionPending: contractCallPending || isSubmitDisabled,
       };
     case FractalProposalState.TIMELOCKABLE:
@@ -271,6 +295,8 @@ export function ExectionSection({ proposal }: { proposal: MultisigProposal }) {
     proposal.transaction
       ? { ...proposal.transaction, data: proposal.transaction.data ?? '0x' }
       : undefined,
+    proposal.proposalId,
+    proposal.nonce,
     true,
   );
 
@@ -286,6 +312,8 @@ export function ExectionSection({ proposal }: { proposal: MultisigProposal }) {
   const rejectionProposalAction = useProposalExecutionButtonAction(
     rejectionProposal?.state,
     rejectionProposal?.transaction,
+    rejectionProposal?.proposalId,
+    rejectionProposal?.nonce,
     false,
   );
 

--- a/src/components/ui/modals/ConfirmationModal.tsx
+++ b/src/components/ui/modals/ConfirmationModal.tsx
@@ -13,7 +13,7 @@ export function ConfirmationModal({
   icon,
 }: {
   title: string;
-  description: string | JSX.Element;
+  description: ReactNode;
   primaryButtonProps: {
     onClick: () => void;
     label: string;

--- a/src/components/ui/modals/ConfirmationModal.tsx
+++ b/src/components/ui/modals/ConfirmationModal.tsx
@@ -1,0 +1,208 @@
+import { Flex, Button, Text, Icon, Box, Image } from '@chakra-ui/react';
+import { WarningCircle } from '@phosphor-icons/react';
+import { ReactNode } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import warningSVG from '../../../../public/images/warning-yellow.svg';
+import { COLOR_CHARCOAL_300 } from '../../../constants/common';
+
+export function ConfirmationModal({
+  title,
+  description,
+  primaryButtonProps,
+  secondaryButtonProps,
+  icon,
+}: {
+  title: string;
+  description: string | JSX.Element;
+  primaryButtonProps: {
+    onClick: () => void;
+    label: string;
+    leftIcon?: JSX.Element;
+  };
+  secondaryButtonProps: {
+    onClick: () => void;
+    label: string;
+    leftIcon?: JSX.Element;
+  };
+  icon?: ReactNode;
+}) {
+  return (
+    <>
+      <Flex
+        direction="column"
+        alignItems="center"
+        px="1rem"
+        pb="1.5rem"
+      >
+        {icon}
+        <Text
+          my="1rem"
+          color="white-0"
+          textStyle="heading-medium"
+        >
+          {title}
+        </Text>
+        {typeof description === 'string' ? (
+          <Text
+            mt="0.5rem"
+            textStyle="labels-large"
+            color={COLOR_CHARCOAL_300}
+          >
+            {description}
+          </Text>
+        ) : (
+          description
+        )}
+      </Flex>
+      <Flex
+        justifyContent="center"
+        gap="0.75rem"
+        mt="1rem"
+        mx="1rem"
+      >
+        <Button
+          w="full"
+          leftIcon={secondaryButtonProps.leftIcon}
+          variant="secondary"
+          px="2rem"
+          onClick={secondaryButtonProps.onClick}
+        >
+          {secondaryButtonProps.label}
+        </Button>
+        <Button
+          w="full"
+          leftIcon={primaryButtonProps.leftIcon}
+          onClick={primaryButtonProps.onClick}
+          px="2rem"
+        >
+          {primaryButtonProps.label}
+        </Button>
+      </Flex>
+    </>
+  );
+}
+
+function ConfirmRejectProposalAdditionalContent() {
+  const { t } = useTranslation(['proposal']);
+  return (
+    <Box>
+      <Text
+        mt="0.5rem"
+        textStyle="labels-large"
+        color={COLOR_CHARCOAL_300}
+        fontStyle="italic"
+      >
+        {t('rejectProposalDescription')}
+      </Text>
+      <Text
+        my="1rem"
+        textStyle="labels-large"
+        color={COLOR_CHARCOAL_300}
+      >
+        {t('rejectProposalAreYouSure')}
+      </Text>
+      <Flex
+        alignItems="center"
+        gap="0.5rem"
+        color="yellow-0"
+        justifyContent="center"
+        my="1rem"
+        pt="1rem"
+      >
+        <Image
+          src={warningSVG}
+          boxSize="1.5rem"
+        />
+        <Text textStyle="body-small">{t('rejectProposalAreYouSureDescription')}</Text>
+      </Flex>
+    </Box>
+  );
+}
+
+export function ConfirmRejectProposalModal({
+  submitRejection,
+  cancel,
+}: {
+  submitRejection: () => void;
+  cancel: () => void;
+}) {
+  const { t } = useTranslation(['proposal']);
+  return (
+    <ConfirmationModal
+      title={t('confirmRejectProposal')}
+      icon={
+        <Icon
+          as={WarningCircle}
+          boxSize="2rem"
+          color="lilac-0"
+        />
+      }
+      description={<ConfirmRejectProposalAdditionalContent />}
+      primaryButtonProps={{
+        onClick: cancel,
+        label: t('rejectProposalNevermind'),
+      }}
+      secondaryButtonProps={{
+        onClick: submitRejection,
+        label: t('rejectProposalYesRejectIt'),
+      }}
+    />
+  );
+}
+
+export function ConfirmExecutionModal({
+  submitExecution,
+  nonce,
+  cancel,
+}: {
+  submitExecution: () => void;
+  nonce: number | undefined;
+  cancel: () => void;
+}) {
+  const { t } = useTranslation(['proposal', 'modals']);
+  return (
+    <ConfirmationModal
+      title={t('confirmExecution')}
+      icon={
+        <Icon
+          as={WarningCircle}
+          boxSize="2rem"
+          color="lilac-0"
+        />
+      }
+      description={
+        <Box>
+          <Text
+            mt="0.5rem"
+            textStyle="labels-large"
+            color={COLOR_CHARCOAL_300}
+            fontStyle="italic"
+          >
+            <Trans
+              t={t}
+              i18nKey="executionDescription"
+              values={{ nonce }}
+              components={{
+                color: (
+                  <Box
+                    as="span"
+                    color="white-0"
+                    fontStyle="normal"
+                  />
+                ),
+              }}
+            />
+          </Text>
+        </Box>
+      }
+      primaryButtonProps={{
+        onClick: submitExecution,
+        label: t('modalContinue', { ns: 'modals' }),
+      }}
+      secondaryButtonProps={{
+        onClick: cancel,
+        label: t('modalCancel', { ns: 'modals' }),
+      }}
+    />
+  );
+}

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -15,6 +15,7 @@ import { AirdropData, AirdropModal } from './AirdropModal/AirdropModal';
 import { ConfirmDeleteStrategyModal } from './ConfirmDeleteStrategyModal';
 import { ConfirmModifyGovernanceModal } from './ConfirmModifyGovernanceModal';
 import { ConfirmUrlModal } from './ConfirmUrlModal';
+import { ConfirmExecutionModal, ConfirmRejectProposalModal } from './ConfirmationModal';
 import { DelegateModal } from './DelegateModal';
 import ForkProposalTemplateModal from './ForkProposalTemplateModal';
 import { GaslessVoteFailedModal } from './GaslessVoting/GaslessVoteFailedModal';
@@ -59,6 +60,9 @@ export enum ModalType {
   DAPPS_BROWSER,
   DAPP_BROWSER,
   SAFE_SETTINGS,
+  CONFIRM_NONCE_EXECUTION,
+  CONFIRM_REJECT_PROPOSAL,
+  CONFIRM_EXECUTION,
 }
 
 export type CurrentModal = {
@@ -132,6 +136,18 @@ export type ModalPropsTypes = {
     appUrl: string;
   };
   [ModalType.SAFE_SETTINGS]: {};
+  [ModalType.CONFIRM_NONCE_EXECUTION]: {
+    nonce: number | undefined;
+    continue: () => void;
+    cancel: () => void;
+  };
+  [ModalType.CONFIRM_REJECT_PROPOSAL]: {
+    submitRejection: () => void;
+  };
+  [ModalType.CONFIRM_EXECUTION]: {
+    nonce: number | undefined;
+    submitExecution: () => void;
+  };
 };
 
 export interface IModalContext {
@@ -415,6 +431,31 @@ export function ModalProvider({ children }: { children: ReactNode }) {
           backgroundColor: NEUTRAL_2_50_TRANSPARENT,
           padding: '0',
         };
+        break;
+      case ModalType.CONFIRM_REJECT_PROPOSAL:
+        modalContent = (
+          <ConfirmRejectProposalModal
+            submitRejection={() => {
+              current.props.submitRejection();
+              closeModal();
+            }}
+            cancel={closeModal}
+          />
+        );
+        modalSize = 'md';
+        break;
+      case ModalType.CONFIRM_EXECUTION:
+        modalContent = (
+          <ConfirmExecutionModal
+            nonce={current.props.nonce}
+            submitExecution={() => {
+              current.props.submitExecution();
+              closeModal();
+            }}
+            cancel={closeModal}
+          />
+        );
+        modalSize = 'md';
         break;
       case ModalType.NONE:
       default:

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -31,6 +31,7 @@ export const BACKGROUND_SEMI_TRANSPARENT = '#16121980';
 export const NEUTRAL_2_82_TRANSPARENT = '#221D25D6';
 export const NEUTRAL_2_50_TRANSPARENT = '#221D2580';
 export const COLOR_TEXT_SUCCESS = '#59CA9C';
+export const COLOR_CHARCOAL_300 = '#ACA1B2';
 export const SEXY_BOX_SHADOW_T_T =
   '0px 0px 0px 1px rgba(248, 244, 252, 0.04) inset, 0px 1px 0px 0px rgba(248, 244, 252, 0.04) inset, 0px 0px 0px 1px #100414';
 


### PR DESCRIPTION
Actual File change (6)
Branched from #3028 

## Screenshots
- Modal that pops up when executing a proposal with multiple sharing nonce (non-rejection)
![localhost_3000_proposals_0xec9132de8f455df2b3bbb60c9dd9dacff71ba3c3f2eaf0be8ac2fe938559c673_dao=sep_0xf11698F5fD6c8B928647342bF6F102A5e6eb9495(Desktop)](https://github.com/user-attachments/assets/3e87de4f-82a1-4de0-9f2b-0180b236a21b)

- Modal that pops up when executing a rejection proposal with multiple sharing nonce
![localhost_3000_proposals_0x7d00c303c5afeb93151e5bd228a0ddcb60af26806a247c74307a0727b42dacd3_dao=sep_0xf11698F5fD6c8B928647342bF6F102A5e6eb9495(Desktop)](https://github.com/user-attachments/assets/63124719-0460-4d00-a863-05bf945d1d25)
