### PR TITLE
`[ENG-883]` Update to Etherscan V2 by May 31, 2025

### DIFF
--- a/.env
+++ b/.env
@@ -59,16 +59,8 @@ VITE_APP_WALLET_CONNECT_PROJECT_ID=""
 # VITE_APP_HOTJAR_VERSION=""
 # Sentry DSN URL, not used locally
 # VITE_APP_SENTRY_DSN_URL=""
-# ABI selector, used on Base
-# VITE_APP_ETHERSCAN_BASE_API_KEY=""
-# ABI selector, used on Mainnet
+# ABI selector, Etherscan API V2 key, used on all supported Chains
 # VITE_APP_ETHERSCAN_MAINNET_API_KEY=""
-# ABI selector, used on Optimism
-# VITE_APP_ETHERSCAN_OPTIMISM_API_KEY=""
-# ABI selector, used on Polygon
-# VITE_APP_ETHERSCAN_POLYGON_API_KEY=""
-# ABI selector, used on Sepolia
-# VITE_APP_ETHERSCAN_SEPOLIA_API_KEY=""
 
 # Firebase configurations
 # VITE_APP_FIREBASE_CONFIG='{
@@ -82,4 +74,3 @@ VITE_APP_WALLET_CONNECT_PROJECT_ID=""
 # }'
 
 # VITE_APP_FIREBASE_TIME_INTERVALS=numeric value in ms
-

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -22,7 +22,7 @@ export const baseConfig: NetworkConfig = {
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: `https://api.basescan.org/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_BASE_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -9,7 +9,7 @@ import { getAddress, zeroAddress } from 'viem';
 import { base } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
-import { getSafeContractDeploymentAddress } from './utils';
+import { getEtherscanAPIUrl, getSafeContractDeploymentAddress } from './utils';
 
 const SAFE_VERSION = '1.3.0';
 
@@ -22,7 +22,10 @@ export const baseConfig: NetworkConfig = {
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: getEtherscanAPIUrl(
+    chain.id,
+    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
+  ),
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -22,7 +22,7 @@ export const baseConfig: NetworkConfig = {
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_BASE_API_KEY}`,
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -22,7 +22,7 @@ export const baseConfig: NetworkConfig = {
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_BASE_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=8453&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -22,10 +22,7 @@ export const baseConfig: NetworkConfig = {
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: getEtherscanAPIUrl(
-    chain.id,
-    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
-  ),
+  etherscanAPIUrl: getEtherscanAPIUrl(chain.id),
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -9,7 +9,7 @@ import { getAddress } from 'viem';
 import { mainnet } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
-import { getSafeContractDeploymentAddress } from './utils';
+import { getEtherscanAPIUrl, getSafeContractDeploymentAddress } from './utils';
 
 const SAFE_VERSION = '1.3.0';
 
@@ -22,7 +22,10 @@ export const mainnetConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-mainnet.safe.global',
   etherscanBaseURL: 'https://etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=1&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: getEtherscanAPIUrl(
+    chain.id,
+    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
+  ),
   addressPrefix: 'eth',
   nativeTokenIcon: '/images/coin-icon-eth.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -22,7 +22,7 @@ export const mainnetConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-mainnet.safe.global',
   etherscanBaseURL: 'https://etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=1&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'eth',
   nativeTokenIcon: '/images/coin-icon-eth.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -22,10 +22,7 @@ export const mainnetConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-mainnet.safe.global',
   etherscanBaseURL: 'https://etherscan.io',
-  etherscanAPIUrl: getEtherscanAPIUrl(
-    chain.id,
-    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
-  ),
+  etherscanAPIUrl: getEtherscanAPIUrl(chain.id),
   addressPrefix: 'eth',
   nativeTokenIcon: '/images/coin-icon-eth.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -22,7 +22,7 @@ export const optimismConfig: NetworkConfig = {
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_OPTIMISM_API_KEY}`,
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -22,7 +22,7 @@ export const optimismConfig: NetworkConfig = {
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_OPTIMISM_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -22,7 +22,7 @@ export const optimismConfig: NetworkConfig = {
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: `https://api-optimistic.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_OPTIMISM_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -22,10 +22,7 @@ export const optimismConfig: NetworkConfig = {
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: getEtherscanAPIUrl(
-    chain.id,
-    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
-  ),
+  etherscanAPIUrl: getEtherscanAPIUrl(chain.id),
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -9,7 +9,7 @@ import { getAddress, zeroAddress } from 'viem';
 import { optimism } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
-import { getSafeContractDeploymentAddress } from './utils';
+import { getEtherscanAPIUrl, getSafeContractDeploymentAddress } from './utils';
 
 const SAFE_VERSION = '1.3.0';
 
@@ -22,7 +22,10 @@ export const optimismConfig: NetworkConfig = {
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=10&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: getEtherscanAPIUrl(
+    chain.id,
+    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
+  ),
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -22,7 +22,7 @@ export const polygonConfig: NetworkConfig = {
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_POLYGON_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -22,7 +22,7 @@ export const polygonConfig: NetworkConfig = {
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: `https://api.polygonscan.com/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_POLYGON_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -9,7 +9,7 @@ import { getAddress, zeroAddress } from 'viem';
 import { polygon } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
-import { getSafeContractDeploymentAddress } from './utils';
+import { getEtherscanAPIUrl, getSafeContractDeploymentAddress } from './utils';
 
 const SAFE_VERSION = '1.3.0';
 
@@ -22,7 +22,10 @@ export const polygonConfig: NetworkConfig = {
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: getEtherscanAPIUrl(
+    chain.id,
+    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
+  ),
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -22,7 +22,7 @@ export const polygonConfig: NetworkConfig = {
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=137&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_POLYGON_API_KEY}`,
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -22,10 +22,7 @@ export const polygonConfig: NetworkConfig = {
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: getEtherscanAPIUrl(
-    chain.id,
-    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
-  ),
+  etherscanAPIUrl: getEtherscanAPIUrl(chain.id),
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   isENSSupported: false,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -22,7 +22,7 @@ export const sepoliaConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: `https://api-sepolia.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_SEPOLIA_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -9,7 +9,7 @@ import { getAddress } from 'viem';
 import { sepolia } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
 import { NetworkConfig } from '../../../types/network';
-import { getSafeContractDeploymentAddress } from './utils';
+import { getEtherscanAPIUrl, getSafeContractDeploymentAddress } from './utils';
 
 const SAFE_VERSION = '1.3.0';
 
@@ -22,7 +22,10 @@ export const sepoliaConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: getEtherscanAPIUrl(
+    chain.id,
+    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
+  ),
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -22,7 +22,7 @@ export const sepoliaConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_SEPOLIA_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -22,7 +22,7 @@ export const sepoliaConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/v2/api?chainid=11155111&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_SEPOLIA_API_KEY}`,
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -22,10 +22,7 @@ export const sepoliaConfig: NetworkConfig = {
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: getEtherscanAPIUrl(
-    chain.id,
-    import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY,
-  ),
+  etherscanAPIUrl: getEtherscanAPIUrl(chain.id),
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   isENSSupported: true,

--- a/src/providers/NetworkConfig/networks/utils.ts
+++ b/src/providers/NetworkConfig/networks/utils.ts
@@ -14,3 +14,7 @@ export const getSafeContractDeploymentAddress = (
   const contractAddress = getAddress(contract);
   return contractAddress;
 };
+
+export const getEtherscanAPIUrl = (chainId: number, apiKey: string) => {
+  return `https://api.etherscan.io/v2/api?chainid=${chainId}&apikey=${apiKey}`;
+};

--- a/src/providers/NetworkConfig/networks/utils.ts
+++ b/src/providers/NetworkConfig/networks/utils.ts
@@ -15,6 +15,6 @@ export const getSafeContractDeploymentAddress = (
   return contractAddress;
 };
 
-export const getEtherscanAPIUrl = (chainId: number, apiKey: string) => {
-  return `https://api.etherscan.io/v2/api?chainid=${chainId}&apikey=${apiKey}`;
+export const getEtherscanAPIUrl = (chainId: number) => {
+  return `https://api.etherscan.io/v2/api?chainid=${chainId}&apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`;
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -18,10 +18,6 @@ interface ImportMetaEnv {
   readonly VITE_APP_HOTJAR_VERSION: string;
   readonly VITE_APP_SENTRY_DSN_URL: string;
   readonly VITE_APP_ETHERSCAN_MAINNET_API_KEY: string;
-  readonly VITE_APP_ETHERSCAN_POLYGON_API_KEY: string;
-  readonly VITE_APP_ETHERSCAN_SEPOLIA_API_KEY: string;
-  readonly VITE_APP_ETHERSCAN_BASE_API_KEY: string;
-  readonly VITE_APP_ETHERSCAN_OPTIMISM_API_KEY: string;
 
   readonly VITE_APP_FIREBASE_CONFIG: string;
   readonly VITE_APP_FIREBASE_TIME_INTERVALS: number;


### PR DESCRIPTION
### Summary

- Update url of etherscan API to V2 which unify all chain access with same url
- All chain will use same `VITE_APP_ETHERSCAN_MAINNET_API_KEY` for Etherscan API V2, no longer need to specify different key for different network.
- Migration doc: https://docs.etherscan.io/etherscan-v2/v2-quickstart

<img width="813" alt="image" src="https://github.com/user-attachments/assets/8f4b64d5-eb33-4e6a-b98f-4e0cf9680107" />


