### PR TITLE
`[ENG-844 ~ to Release]` BugFix Paymaster deposit info missing

### DIFF
--- a/.env
+++ b/.env
@@ -44,7 +44,7 @@ VITE_APP_WALLET_CONNECT_PROJECT_ID=""
 ##
 # VITE_APP_FLAG_DEV=""
 # VITE_APP_FLAG_ANOTHER_EXAMPLE=""
-
+VITE_APP_FLAG_GASLESS_VOTING="ON"
 ##########
 ## Optional variables without default values
 ##

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -199,6 +199,7 @@ const useKeyValuePairs = () => {
           accountAbstraction,
         ).then(gaslessVotingDaoData => {
           if (gaslessVotingDaoData) {
+            // @TODO swap out for setter in `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
             action.dispatch({
               type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
               payload: gaslessVotingDaoData,
@@ -245,6 +246,7 @@ const useKeyValuePairs = () => {
             accountAbstraction,
           ).then(gaslessVotingDaoData => {
             if (gaslessVotingDaoData) {
+              // @TODO swap out for setter in `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
               action.dispatch({
                 type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
                 payload: gaslessVotingDaoData,
@@ -257,6 +259,7 @@ const useKeyValuePairs = () => {
     return () => {
       unwatch();
     };
+    // @TODO remove `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     keyValuePairs,

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -199,7 +199,6 @@ const useKeyValuePairs = () => {
           accountAbstraction,
         ).then(gaslessVotingDaoData => {
           if (gaslessVotingDaoData) {
-            // @TODO swap out for setter in `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
             action.dispatch({
               type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
               payload: gaslessVotingDaoData,
@@ -246,7 +245,6 @@ const useKeyValuePairs = () => {
             accountAbstraction,
           ).then(gaslessVotingDaoData => {
             if (gaslessVotingDaoData) {
-              // @TODO swap out for setter in `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
               action.dispatch({
                 type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
                 payload: gaslessVotingDaoData,
@@ -259,7 +257,6 @@ const useKeyValuePairs = () => {
     return () => {
       unwatch();
     };
-    // @TODO remove `useGlobalStore` when ready: https://linear.app/decent-labs/issue/ENG-898/update-gaslessvoting-setter-to-function-setter
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     keyValuePairs,

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -5,6 +5,7 @@ import { Address, GetContractEventsReturnType, PublicClient, getContract } from 
 import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { logError } from '../../helpers/errorLogging';
 import { useDAOStore } from '../../providers/App/AppProvider';
+import { FractalGovernanceAction } from '../../providers/App/governance/action';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { useRolesStore } from '../../store/roles/useRolesStore';
 import { getPaymasterAddress } from '../../utils/gaslessVoting';
@@ -158,7 +159,8 @@ const useKeyValuePairs = () => {
   } = useNetworkConfigStore();
   const { daoKey } = useCurrentDAOKey();
   const {
-    node: { safe, setGaslessVotingDaoData },
+    node: { safe },
+    action,
   } = useDAOStore({ daoKey });
   const { setHatKeyValuePairData, resetHatsStore } = useRolesStore();
   const safeAddress = safe?.address;
@@ -197,7 +199,10 @@ const useKeyValuePairs = () => {
           accountAbstraction,
         ).then(gaslessVotingDaoData => {
           if (gaslessVotingDaoData) {
-            setGaslessVotingDaoData(gaslessVotingDaoData);
+            action.dispatch({
+              type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
+              payload: gaslessVotingDaoData,
+            });
           }
         });
       })
@@ -240,7 +245,10 @@ const useKeyValuePairs = () => {
             accountAbstraction,
           ).then(gaslessVotingDaoData => {
             if (gaslessVotingDaoData) {
-              setGaslessVotingDaoData(gaslessVotingDaoData);
+              action.dispatch({
+                type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA,
+                payload: gaslessVotingDaoData,
+              });
             }
           });
         },
@@ -249,13 +257,13 @@ const useKeyValuePairs = () => {
     return () => {
       unwatch();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     keyValuePairs,
     safeAddress,
     publicClient,
     setHatKeyValuePairData,
     sablierV2LockupLinear,
-    setGaslessVotingDaoData,
     accountAbstraction,
     paymaster,
     zodiacModuleProxyFactory,

--- a/src/providers/App/AppProvider.tsx
+++ b/src/providers/App/AppProvider.tsx
@@ -57,9 +57,6 @@ export const useDAOStore = ({ daoKey }: { daoKey: DAOKey | undefined }): Fractal
         resetDaoInfoStore: () => {
           // Do nothing - global store currently not supposed to reset anything
         },
-        setGaslessVotingDaoData: () => {
-          // Do nothing - this is handled in governance slice
-        },
       },
       treasury,
       governance,

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -8,6 +8,7 @@ import {
   VotingStrategy,
   GovernanceType,
   ERC721TokenData,
+  GaslessVotingDaoData,
 } from '../../../types';
 import { ProposalTemplate } from '../../../types/proposalBuilder';
 
@@ -30,6 +31,7 @@ export enum FractalGovernanceAction {
   SET_CLAIMING_CONTRACT = 'SET_CLAIMING_CONTRACT',
   RESET_TOKEN_ACCOUNT_DATA = 'RESET_TOKEN_ACCOUNT_DATA',
   PENDING_PROPOSAL_ADD = 'PENDING_PROPOSAL_ADD',
+  SET_GASLESS_VOTING_DATA = 'SET_GASLESS_VOTING_DATA',
 }
 
 export enum DecentGovernanceAction {
@@ -100,6 +102,10 @@ export type FractalGovernanceActions =
   | {
       type: FractalGovernanceAction.PENDING_PROPOSAL_ADD;
       payload: string;
+    }
+  | {
+      type: FractalGovernanceAction.SET_GASLESS_VOTING_DATA;
+      payload: GaslessVotingDaoData;
     }
   | DecentGovernanceActions;
 

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -201,6 +201,9 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
     case FractalGovernanceAction.PENDING_PROPOSAL_ADD: {
       return { ...state, pendingProposals: [action.payload, ...(state.pendingProposals || [])] };
     }
+    case FractalGovernanceAction.SET_GASLESS_VOTING_DATA: {
+      return { ...state, ...action.payload };
+    }
     // Decent Governance only
     case DecentGovernanceAction.SET_LOCKED_TOKEN_ACCOUNT_DATA: {
       const { lockedVotesToken } = state as DecentGovernance;

--- a/src/store/daoInfo/useDaoInfoStore.ts
+++ b/src/store/daoInfo/useDaoInfoStore.ts
@@ -3,7 +3,6 @@ import { create } from 'zustand';
 import {
   DAOSubgraph,
   DecentModule,
-  GaslessVotingDaoData,
   IDAO,
   SafeWithNextNonce,
 } from '../../types';
@@ -24,7 +23,6 @@ export interface DaoInfoStore extends IDAO {
   setDaoInfo: (daoInfo: DAOSubgraph) => void;
   setDecentModules: (modules: DecentModule[]) => void;
   resetDaoInfoStore: () => void;
-  setGaslessVotingDaoData: (gaslessVotingDaoData: GaslessVotingDaoData) => void;
 }
 
 export const useDaoInfoStore = create<DaoInfoStore>()(set => ({
@@ -53,11 +51,5 @@ export const useDaoInfoStore = create<DaoInfoStore>()(set => ({
     set({ modules });
   },
 
-  resetDaoInfoStore: () => set(initialDaoInfoStore),
-  setGaslessVotingDaoData: (gaslessVotingDaoData: GaslessVotingDaoData) => {
-    set(state => ({
-      ...state,
-      ...gaslessVotingDaoData,
-    }));
-  },
+  resetDaoInfoStore: () => set(initialDaoInfoStore)
 }));

--- a/src/store/daoInfo/useDaoInfoStore.ts
+++ b/src/store/daoInfo/useDaoInfoStore.ts
@@ -1,11 +1,6 @@
 import { Address, getAddress } from 'viem';
 import { create } from 'zustand';
-import {
-  DAOSubgraph,
-  DecentModule,
-  IDAO,
-  SafeWithNextNonce,
-} from '../../types';
+import { DAOSubgraph, DecentModule, IDAO, SafeWithNextNonce } from '../../types';
 
 export const initialDaoInfoStore: IDAO & {
   gaslessVotingEnabled: boolean;
@@ -51,5 +46,5 @@ export const useDaoInfoStore = create<DaoInfoStore>()(set => ({
     set({ modules });
   },
 
-  resetDaoInfoStore: () => set(initialDaoInfoStore)
+  resetDaoInfoStore: () => set(initialDaoInfoStore),
 }));


### PR DESCRIPTION
So looked like `gaslessVotingData` was split between places. The components were looking for it in governance, and the new globalStore sets in there. But the old setup has it in `useDAOStore` as well as the setters. 

So for now I moved it out of `useDAOStore` and remove the typing. I've added the new action to the governance reducer/actions and set the action up in `useKeyValuePairs` with a TODO to replace it with the correct setter when the `useGlobalStore` feature is released

## Screenshot
![localhost_3000_settings_general_dao=sep_0x57cAA14E791B70981cfAa1DE4f3039d0Bf1717D7(Desktop)](https://github.com/user-attachments/assets/2af3f247-203b-4573-a200-8819924a8a23)

