### PR TITLE
`[ENG-899]` move code of nance editor into our repo for easier customization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
         "@hotjar/browser": "^1.0.9",
-        "@nance/nance-editor": "^1.8.4",
         "@phosphor-icons/react": "^2.1.4",
         "@reown/walletkit": "^1.2.2",
         "@safe-global/api-kit": "^2.4.2",
@@ -29,6 +28,7 @@
         "@sentry/vite-plugin": "^3.4.0",
         "@shutter-network/shutter-crypto": "^1.0.1",
         "@tanstack/react-query": "^5.36.2",
+        "@toast-ui/react-editor": "^3.2.3",
         "@torchauth/vite-plugin-wrangler-spa": "^2.0.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "@walletconnect/core": "^2.19.1",
@@ -7104,29 +7104,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@nance/nance-editor": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@nance/nance-editor/-/nance-editor-1.8.5.tgz",
-      "integrity": "sha512-/MAk3AY69dEl5IKcorlCcLQKXULXnXjP8d3pwDKjbFd6PSWWkVJ78Yyy/5WaRF9YKTMuXKTmQik7O180TUjMDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@toast-ui/react-editor": "^3.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0"
-      }
-    },
-    "node_modules/@nance/nance-editor/node_modules/@toast-ui/react-editor": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@toast-ui/react-editor/-/react-editor-3.2.3.tgz",
-      "integrity": "sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==",
-      "dependencies": {
-        "@toast-ui/editor": "^3.2.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.1"
-      }
-    },
     "node_modules/@netlify/blobs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
@@ -10062,6 +10039,17 @@
         "prosemirror-model": "^1.14.1",
         "prosemirror-state": "^1.3.4",
         "prosemirror-view": "^1.18.7"
+      }
+    },
+    "node_modules/@toast-ui/react-editor": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@toast-ui/react-editor/-/react-editor-3.2.3.tgz",
+      "integrity": "sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==",
+      "dependencies": {
+        "@toast-ui/editor": "^3.2.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.1"
       }
     },
     "node_modules/@torchauth/vite-plugin-wrangler-spa": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
     "@hotjar/browser": "^1.0.9",
-    "@nance/nance-editor": "^1.8.4",
     "@phosphor-icons/react": "^2.1.4",
     "@reown/walletkit": "^1.2.2",
     "@safe-global/api-kit": "^2.4.2",
@@ -24,6 +23,7 @@
     "@sentry/vite-plugin": "^3.4.0",
     "@shutter-network/shutter-crypto": "^1.0.1",
     "@tanstack/react-query": "^5.36.2",
+    "@toast-ui/react-editor": "^3.2.3",
     "@torchauth/vite-plugin-wrangler-spa": "^2.0.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "@walletconnect/core": "^2.19.1",
@@ -117,5 +117,10 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.3",
     "vitest": "^1.2.2"
+  },
+  "overrides": {
+    "@toast-ui/react-editor": {
+      "react": "^18.2.0"
+    }
   }
 }

--- a/src/components/Markdown/MarkdownEditor.tsx
+++ b/src/components/Markdown/MarkdownEditor.tsx
@@ -21,6 +21,10 @@ export function MarkdownEditor({
   const { add } = useIPFSClient();
 
   const editor = editorRef.current?.getInstance();
+  // it can't be a empty string which cause a weird bug that value becomes something else.
+  //   Workaround: set it to a string with a space.
+  // check https://github.com/nhn/tui.editor/issues/3206
+  const editorInitialValue = initialValue || ' ';
 
   return (
     <Box
@@ -54,7 +58,7 @@ export function MarkdownEditor({
         ref={editorRef}
         usageStatistics={false}
         placeholder={placeholder}
-        initialValue={initialValue}
+        initialValue={editorInitialValue}
         previewStyle="tab"
         height={height}
         initialEditType="wysiwyg"

--- a/src/components/Markdown/MarkdownEditor.tsx
+++ b/src/components/Markdown/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@chakra-ui/react';
 import { Editor } from '@toast-ui/react-editor';
 import { useRef, useState } from 'react';
 import useIPFSClient, { GATEWAY_URL } from '../../providers/App/hooks/useIPFSClient';
@@ -22,7 +23,7 @@ export function MarkdownEditor({
   const editor = editorRef.current?.getInstance();
 
   return (
-    <div
+    <Box
       onDrop={async e => {
         e.preventDefault();
 
@@ -44,7 +45,11 @@ export function MarkdownEditor({
         }
       }}
     >
-      <div style={{ height: '2px', backgroundColor: '#4f46e5', width: `${uploadedPercent}%` }} />
+      <Box
+        height="0.25rem"
+        bgColor="blue-0"
+        width={`${uploadedPercent}%`}
+      />
       <Editor
         ref={editorRef}
         usageStatistics={false}
@@ -70,6 +75,6 @@ export function MarkdownEditor({
         }}
         theme="dark"
       />
-    </div>
+    </Box>
   );
 }

--- a/src/components/ProposalBuilder/ProposalMetadata.tsx
+++ b/src/components/ProposalBuilder/ProposalMetadata.tsx
@@ -1,17 +1,18 @@
 import { Container, Input, VStack } from '@chakra-ui/react';
-import { NanceEditor } from '@nance/nance-editor';
 import { FormikProps } from 'formik';
 import { TFunction } from 'i18next';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import useFeatureFlag from '../../helpers/environmentFeatureFlags';
-import { GATEWAY_URL, INFURA_AUTH } from '../../providers/App/hooks/useIPFSClient';
 import { useProposalActionsStore } from '../../store/actions/useProposalActionsStore';
 import { CreateProposalForm } from '../../types/proposalBuilder';
+import { MarkdownEditor } from '../Markdown/MarkdownEditor';
 import { CustomNonceInput } from '../ui/forms/CustomNonceInput';
 import { InputComponent, TextareaComponent } from '../ui/forms/InputComponent';
-import '@nance/nance-editor/lib/css/editor.css';
-import '@nance/nance-editor/lib/css/dark.css';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@toast-ui/editor/dist/toastui-editor.css';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 
 export interface ProposalMetadataTypeProps {
   titleLabel: string;
@@ -127,11 +128,9 @@ export function MarkdownProposalMetadata({
         padding={0}
         maxW={{ base: '350px', sm: '440px', md: '768px', lg: '1100px', xl: '1200px' }}
       >
-        <NanceEditor
+        <MarkdownEditor
           initialValue={initialDescription}
-          onEditorChange={value => setProposalMetadata('description', value)}
-          fileUploadIPFS={{ gateway: GATEWAY_URL, auth: INFURA_AUTH }}
-          darkMode={true}
+          onChange={value => setProposalMetadata('description', value)}
           height="400px"
         />
       </Container>


### PR DESCRIPTION
### Summary

Note: this PR should act like a refactor which introduce no new feature or break things.

- Use Editor from package [@toast-ui/react-editor](https://www.npmjs.com/package/@toast-ui/react-editor) directly instead of indirectly through [@nance/nance-editor](https://www.npmjs.com/package/@nance/nance-editor).
- Specify type for `useIPFSClient.add`, re-throw error to ensure type-safety. (it's by default return `undefined` when error get caught before)
- Add `onProgress` callback to `useIPFSClient.add` which can be used by `Editor` to display a progress bar when uploading file to IPFS.