### PR TITLE
`ENG-900` Sentry vite plugin loadEnv

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,33 +1,37 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { viteWranglerSpa } from '@torchauth/vite-plugin-wrangler-spa';
 import react from '@vitejs/plugin-react-swc';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import { checker } from 'vite-plugin-checker';
 import packageJson from './package.json';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    checker({ typescript: true }),
-    viteWranglerSpa(),
-    sentryVitePlugin({
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      sourcemaps: {
-        filesToDeleteAfterUpload: '**/*.map',
-      },
-      telemetry: false,
-    }),
-  ],
-  server: {
-    port: 3000,
-  },
-  build: {
-    sourcemap: true,
-  },
-  define: {
-    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  console.log(env.SENTRY_ORG);
+  return {
+    plugins: [
+      react(),
+      checker({ typescript: true }),
+      viteWranglerSpa(),
+      sentryVitePlugin({
+        org: env.SENTRY_ORG,
+        project: env.SENTRY_PROJECT,
+        authToken: env.SENTRY_AUTH_TOKEN,
+        sourcemaps: {
+          filesToDeleteAfterUpload: '**/*.map',
+        },
+        telemetry: false,
+      }),
+    ],
+    server: {
+      port: 3000,
+    },
+    build: {
+      sourcemap: true,
+    },
+    define: {
+      'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
+    },
+  };
 });


### PR DESCRIPTION
`vite.config.mts` cannot utilize env variables until they are properly loaded
https://vite.dev/config/#using-environment-variables-in-config

This PR properly loads environment variables from `.env.local` so they can be used to upload the source maps to Sentry

This previous PR did not properly implement https://github.com/decentdao/decent-app/pull/2998/files#diff-aecb1f3b195d78a5042d9dc6baab4d7bae9d7d09ffe8b3398634b897bdb441df 