### PR TITLE
`[ENG-911]` Editor hot fixes

### DIFF
--- a/src/components/Markdown/MarkdownEditor.tsx
+++ b/src/components/Markdown/MarkdownEditor.tsx
@@ -59,11 +59,35 @@ export function MarkdownEditor({
         usageStatistics={false}
         placeholder={placeholder}
         initialValue={editorInitialValue}
-        previewStyle="tab"
+        previewStyle="vertical"
         height={height}
         initialEditType="wysiwyg"
         useCommandShortcut={true}
         referenceDefinition={true}
+        toolbarItems={[
+          [
+            'heading',
+            'bold',
+            'italic',
+            'strike',
+            'ul',
+            'ol',
+            'task',
+            'indent',
+            'outdent',
+            'table',
+            'image',
+            'link',
+            'code',
+            'codeblock',
+            'hr',
+            'quote',
+          ],
+        ]}
+        linkAttributes={{
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        }}
         onBeforeConvertWysiwygToMarkdown={(md: string) => {
           return md.replace(/\\(_)/g, '$1'); // Remove escaped underscores
         }}


### PR DESCRIPTION
 1. toolbar item consolidation
   * remove vertical bars separating subsections of toolbar
   * move horizontal line and blockquote to the end of toolbar
 2. vertical markdown preview
       ![image](https://github.com/user-attachments/assets/e305ef69-a77b-4beb-b53b-0a17311250c9)
 3. open links in new tab