### PR TITLE
`[ENG-880]` add back customNonce field with markdown editor, no new design yet

### DIFF
--- a/src/components/ProposalBuilder/ProposalMetadata.tsx
+++ b/src/components/ProposalBuilder/ProposalMetadata.tsx
@@ -128,6 +128,12 @@ export function MarkdownProposalMetadata({
           height="400px"
         />
       </Container>
+      <CustomNonceInput
+        nonce={proposalMetadata.nonce}
+        onChange={newNonce => setProposalMetadata('nonce', newNonce)}
+        align="end"
+        renderTrimmed={false}
+      />
     </VStack>
   );
 }


### PR DESCRIPTION
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/4707019d-db48-43e6-a8a6-038805fc3ba6" />
