### PR TITLE
No Issue: Remove Lint warning

### DIFF
--- a/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
+++ b/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
@@ -350,7 +350,7 @@ export function AddCreateProposalPermissionModal({
       navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safe.address));
     }
   };
-
+  console.log(handleCreateProposal);
   function FormContent() {
     return (
       <SettingsPermissionsStrategyForm


### PR DESCRIPTION
Add a console.log on the function to remove unused variable lint warning. I thought about commenting but it would require several other comments, this seemed min changes. This is behind the Settings flag so shouldn't effect anything. 