### PR TITLE
`ENG-826` | Remove Modal.NONE

### DIFF
--- a/src/components/DAOTreasury/hooks/useTreasuryLidoInteractions.ts
+++ b/src/components/DAOTreasury/hooks/useTreasuryLidoInteractions.ts
@@ -27,7 +27,7 @@ export default function useTreasuryLidoInteractions() {
     Object.keys(staking).length > 0 &&
     ethAsset &&
     BigInt(ethAsset.balance) > 0n;
-  const openStakingModal = useDecentModal(ModalType.STAKE);
+  const { open: openStakingModal } = useDecentModal(ModalType.STAKE);
 
   // --- Lido Unstake button setup ---
   const stETHAsset = assetsFungible.find(

--- a/src/components/DaoDashboard/Activities/ProposalsHome.tsx
+++ b/src/components/DaoDashboard/Activities/ProposalsHome.tsx
@@ -82,7 +82,7 @@ export function ProposalsHome() {
 
   const { addressPrefix } = useNetworkConfigStore();
   const azoriusGovernance = governance as AzoriusGovernance;
-  const delegate = useDecentModal(ModalType.DELEGATE);
+  const { open: delegate } = useDecentModal(ModalType.DELEGATE);
 
   const canDelegate = useMemo(() => {
     if (azoriusGovernance.type === GovernanceType.AZORIUS_ERC20) {

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -121,7 +121,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
   const { addAction, resetActions } = useProposalActionsStore();
   const { data: walletClient } = useNetworkWalletClient();
 
-  const withdrawGas = useDecentModal(ModalType.WITHDRAW_GAS, {
+  const { open: withdrawGas } = useDecentModal(ModalType.WITHDRAW_GAS, {
     onWithdraw: async (withdrawGasData: WithdrawGasData) => {
       if (!safe?.address || !paymasterAddress) {
         return;
@@ -158,7 +158,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
     },
   });
 
-  const refillGas = useDecentModal(ModalType.REFILL_GAS, {
+  const { open: refillGas } = useDecentModal(ModalType.REFILL_GAS, {
     onSubmit: async (refillGasData: RefillGasData) => {
       if (!safe?.address || !paymasterAddress || !accountAbstraction) {
         return;

--- a/src/components/ProposalDapps/DappCard.tsx
+++ b/src/components/ProposalDapps/DappCard.tsx
@@ -22,7 +22,7 @@ export default function DappCard({
   categories,
   onClose,
 }: DappCardProps) {
-  const openDappBrowserModal = useDecentModal(ModalType.DAPP_BROWSER, {
+  const { open: openDappBrowserModal } = useDecentModal(ModalType.DAPP_BROWSER, {
     appUrl,
   });
 

--- a/src/components/ProposalTemplates/ProposalTemplateCard.tsx
+++ b/src/components/ProposalTemplates/ProposalTemplateCard.tsx
@@ -40,10 +40,10 @@ export default function ProposalTemplateCard({
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const { title, description } = proposalTemplate;
 
-  const openProposalForm = useDecentModal(ModalType.CREATE_PROPOSAL_FROM_TEMPLATE, {
+  const { open: openProposalForm } = useDecentModal(ModalType.CREATE_PROPOSAL_FROM_TEMPLATE, {
     proposalTemplate,
   });
-  const openForkTemplateForm = useDecentModal(ModalType.COPY_PROPOSAL_TEMPLATE, {
+  const { open: openForkTemplateForm } = useDecentModal(ModalType.COPY_PROPOSAL_TEMPLATE, {
     proposalTemplate,
     templateIndex,
   });

--- a/src/components/Proposals/MultisigProposalDetails/ExecutionSection.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/ExecutionSection.tsx
@@ -188,7 +188,7 @@ function useProposalExecutionButtonAction(
     }
   };
 
-  const openExecutionConfirmModal = useDecentModal(ModalType.CONFIRM_EXECUTION, {
+  const { open: openExecutionConfirmModal } = useDecentModal(ModalType.CONFIRM_EXECUTION, {
     nonce: proposalNonce,
     submitExecution: () =>
       executeMultisigProposal({

--- a/src/components/Proposals/MultisigProposalDetails/SignatureSection.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/SignatureSection.tsx
@@ -226,9 +226,12 @@ export function SignatureSection({ proposal }: { proposal: MultisigProposal }) {
     });
   };
 
-  const openConfirmRejectProposalModal = useDecentModal(ModalType.CONFIRM_REJECT_PROPOSAL, {
-    submitRejection: handleConfirmSubmitRejectionProposal,
-  });
+  const { open: openConfirmRejectProposalModal } = useDecentModal(
+    ModalType.CONFIRM_REJECT_PROPOSAL,
+    {
+      submitRejection: handleConfirmSubmitRejectionProposal,
+    },
+  );
   const showConfirmRejectProposalModal = !rejectionProposal && conflictingProposals?.length;
 
   const isDoNotShowStates =

--- a/src/components/Proposals/ProposalActions/CastVote.tsx
+++ b/src/components/Proposals/ProposalActions/CastVote.tsx
@@ -53,8 +53,8 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
 
   const { canVoteLoading, hasVoted, hasVotedLoading } = useVoteContext();
   const [doRetryGaslessVote, setDoRetryGaslessVote] = useState(false);
-  const gaslessVoteSuccessModal = useDecentModal(ModalType.GASLESS_VOTE_SUCCESS);
-  const gaslessVoteFailedModal = useDecentModal(ModalType.GASLESS_VOTE_FAILED, {
+  const { open: gaslessVoteSuccessModal } = useDecentModal(ModalType.GASLESS_VOTE_SUCCESS);
+  const { open: gaslessVoteFailedModal } = useDecentModal(ModalType.GASLESS_VOTE_FAILED, {
     onRetry: () => {
       setDoRetryGaslessVote(true);
     },

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Flex, Link, Text } from '@chakra-ui/react';
 import { ArrowUpRight } from '@phosphor-icons/react';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Shield } from '../../assets/theme/custom/icons/Shield';
 import { findMostConfirmedMultisigRejectionProposal } from '../../helpers/multisigProposal';
@@ -60,19 +59,9 @@ export function ProposalInfo({
   } = useDAOStore({ daoKey });
   const { snapshotProposal } = useSnapshotProposal(proposal);
 
-  const [modalType, props] = useMemo(() => {
-    if (!metaData.documentationUrl) {
-      return [ModalType.NONE] as const;
-    }
-    return [
-      ModalType.CONFIRM_URL,
-      {
-        url: metaData.documentationUrl,
-      },
-    ] as const;
-  }, [metaData.documentationUrl]);
-
-  const confirmUrl = useDecentModal(modalType, props);
+  const { open: confirmUrl } = useDecentModal(ModalType.CONFIRM_URL, {
+    url: metaData.documentationUrl,
+  });
 
   const rejectionProposal = findMostConfirmedMultisigRejectionProposal(
     safe?.address,

--- a/src/components/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStream.tsx
@@ -131,18 +131,16 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
     ? existingPayment.canUserCancel() && !payment?.isCancelling
     : false;
 
-  const cancelModal = useDecentModal(ModalType.NONE);
   const handleConfirmCancelPayment = useCallback(() => {
     if (!payment) {
       return;
     }
 
     setFieldValue(`roleEditing.payments.${formIndex}`, { ...payment, isCancelling: true });
-    cancelModal();
     setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);
-  }, [setFieldValue, formIndex, cancelModal, payment]);
+  }, [setFieldValue, formIndex, payment]);
 
-  const confirmCancelPayment = useDecentModal(ModalType.CONFIRM_CANCEL_PAYMENT, {
+  const { open: confirmCancelPayment } = useDecentModal(ModalType.CONFIRM_CANCEL_PAYMENT, {
     onSubmit: handleConfirmCancelPayment,
   });
 

--- a/src/components/SafeSettings/Signers/SignersContainer.tsx
+++ b/src/components/SafeSettings/Signers/SignersContainer.tsx
@@ -166,17 +166,10 @@ export function SignersContainer() {
     }
   }, [setFieldValue, values.multisig]);
 
-  const [addSignerModalType, addSignerModalProps] = useMemo(() => {
-    if (safe?.threshold === undefined) {
-      return [ModalType.NONE] as const;
-    }
-
-    return [
-      ModalType.ADD_SIGNER,
-      { signers: signers.map(s => s.address), currentThreshold: safe.threshold },
-    ] as const;
-  }, [signers, safe?.threshold]);
-  const showAddSignerModal = useDecentModal(addSignerModalType, addSignerModalProps);
+  const { open: showAddSignerModal } = useDecentModal(ModalType.ADD_SIGNER, {
+    signers: signers.map(s => s.address),
+    currentThreshold: safe?.threshold,
+  });
 
   const { address: account } = useAccount();
   const enableRemove = userIsSigner && signers.length > 1;
@@ -206,32 +199,7 @@ export function SignersContainer() {
 
   const isSettingsV1FeatureEnabled = useFeatureFlag('flag_settings_v1');
 
-  const [removingSigner, setRemovingSigner] = useState<SignerItem>();
-
-  const [removeSignerModalType, removeSignerModalProps] = useMemo(() => {
-    if (!safe?.threshold || !removingSigner?.address) {
-      return [ModalType.NONE] as const;
-    }
-
-    return [
-      ModalType.REMOVE_SIGNER,
-      {
-        selectedSigner: removingSigner.address,
-        signers: signers.map(s => s.address),
-        currentThreshold: safe.threshold,
-      },
-    ] as const;
-  }, [removingSigner, signers, safe?.threshold]);
-  const showRemoveSignerModal = useDecentModal(removeSignerModalType, removeSignerModalProps);
-
-  useEffect(() => {
-    if (removingSigner) {
-      showRemoveSignerModal();
-      setRemovingSigner(undefined);
-    }
-  }, [removingSigner, showRemoveSignerModal]);
-
-  const handleModifyGovernance = useDecentModal(ModalType.CONFIRM_MODIFY_GOVERNANCE);
+  const { open: handleModifyGovernance } = useDecentModal(ModalType.CONFIRM_MODIFY_GOVERNANCE);
 
   // Calculate if we can remove more signers
   const canRemoveMoreSigners = useMemo(() => {

--- a/src/components/ui/menus/CreateProposalMenu/index.tsx
+++ b/src/components/ui/menus/CreateProposalMenu/index.tsx
@@ -17,7 +17,7 @@ export function CreateProposalMenu({ safeAddress }: { safeAddress: Address }) {
 
   const { addressPrefix } = useNetworkConfigStore();
   const { resetActions } = useProposalActionsStore();
-  const openDappsBrowserModal = useDecentModal(ModalType.DAPPS_BROWSER);
+  const { open: openDappsBrowserModal } = useDecentModal(ModalType.DAPPS_BROWSER);
 
   const navigate = useNavigate();
   const iframeFeatureEnabled = useFeatureFlag('flag_iframe_template');

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -46,7 +46,7 @@ export function ManageDAOMenu() {
 
   const { addressPrefix } = useNetworkConfigStore();
 
-  const openSettingsModal = useDecentModal(ModalType.SAFE_SETTINGS);
+  const { open: openSettingsModal } = useDecentModal(ModalType.SAFE_SETTINGS);
 
   const settingsV1FeatureEnabled = useFeatureFlag('flag_settings_v1');
   const isMobile = useBreakpointValue({ base: true, md: false });
@@ -61,7 +61,7 @@ export function ManageDAOMenu() {
     }
   }, [safeAddress, isMobile, settingsV1FeatureEnabled, navigate, addressPrefix, openSettingsModal]);
 
-  const handleModifyGovernance = useDecentModal(ModalType.CONFIRM_MODIFY_GOVERNANCE);
+  const { open: handleModifyGovernance } = useDecentModal(ModalType.CONFIRM_MODIFY_GOVERNANCE);
 
   const { data: walletClient } = useNetworkWalletClient();
 

--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -80,7 +80,7 @@ export function AddActions() {
   const { addAction } = useProposalActionsStore();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
+  const { open: openSendAssetsModal } = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsData => {
       const { action } = prepareSendAssetsActionData(sendAssetsData);
 
@@ -89,7 +89,7 @@ export function AddActions() {
     submitButtonText: t('Add Action', { ns: 'modals' }),
   });
 
-  const openTransactionBuilderModal = useDecentModal(ModalType.TRANSACTION_BUILDER, {
+  const { open: openTransactionBuilderModal } = useDecentModal(ModalType.TRANSACTION_BUILDER, {
     onSubmit: transactionBuilderData => {
       const actionType = ProposalActionType.TRANSACTION_BUILDER;
 

--- a/src/components/ui/modals/PaymentCancelConfirmModal.tsx
+++ b/src/components/ui/modals/PaymentCancelConfirmModal.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next';
 
 export default function PaymentCancelConfirmModal({
   onSubmit,
-  onClose,
+  closeModal,
 }: {
   onSubmit: () => void;
-  onClose: () => void;
+  closeModal: () => void;
 }) {
   const { t } = useTranslation(['roles', 'common']);
 
@@ -42,12 +42,15 @@ export default function PaymentCancelConfirmModal({
           _hover={{ color: 'red-0', borderColor: 'red-0' }}
           variant="secondary"
           leftIcon={<Trash />}
-          onClick={onSubmit}
+          onClick={() => {
+            onSubmit();
+            closeModal();
+          }}
         >
           {t('cancelPayment')}
         </Button>
         <Button
-          onClick={onClose}
+          onClick={closeModal}
           width="100%"
         >
           {t('cancel', { ns: 'common' })}

--- a/src/components/ui/modals/PaymentWithdrawModal.tsx
+++ b/src/components/ui/modals/PaymentWithdrawModal.tsx
@@ -35,7 +35,7 @@ export function PaymentWithdrawModal({
     recipient: Address;
     withdrawableAmount: bigint;
   };
-  onSuccess: () => Promise<void>;
+  onSuccess: () => void;
   onClose: () => void;
 }) {
   const { data: walletClient } = useNetworkWalletClient();
@@ -89,8 +89,8 @@ export function PaymentWithdrawModal({
         failedMessage: t('withdrawRevertedMessage'),
         successMessage: t('withdrawSuccessMessage'),
         failedCallback: () => {},
-        successCallback: async () => {
-          await onSuccess();
+        successCallback: () => {
+          onSuccess();
           onClose();
         },
         completedCallback: () => {},

--- a/src/components/ui/modals/useDecentModal.tsx
+++ b/src/components/ui/modals/useDecentModal.tsx
@@ -8,19 +8,23 @@ import {
 } from './ModalProvider';
 
 /**
- * Returns a Function intended to be used in a click listener to open the provided ModalType.
+ * Returns an object with `open` and `close` functions to control the provided ModalType modal.
  *
  * @param modal the ModalType to open.
  * @param props optional arbitrary key:value properties to pass to the modal
- * @returns a Function that when called opens the provided ModalType modal.
  */
 export const useDecentModal = <T extends ModalType>(modal: T, props?: ModalPropsTypes[T]) => {
-  const { pushModal, openModals } = useContext<IModalContext>(ModalContext);
-  return () => {
-    const modalObject = { type: modal, props: props ?? {} } as ModalTypeWithProps;
+  const { pushModal, openModals, popModal } = useContext<IModalContext>(ModalContext);
+  return {
+    open: () => {
+      const modalObject = { type: modal, props: props ?? {} } as ModalTypeWithProps;
 
-    if (openModals.findIndex(m => m.type === modal) === -1) {
-      pushModal(modalObject);
-    }
+      if (openModals.findIndex(m => m.type === modal) === -1) {
+        pushModal(modalObject);
+      }
+    },
+    close: () => {
+      popModal();
+    },
   };
 };

--- a/src/hooks/DAO/proposal/useCastVote.ts
+++ b/src/hooks/DAO/proposal/useCastVote.ts
@@ -276,8 +276,9 @@ const useCastVote = (proposalId: string, strategy: Address) => {
     publicClient,
   ]);
 
-  const gaslessVoteLoadingModal = useDecentModal(ModalType.GASLESS_VOTE_LOADING);
-  const closeModal = useDecentModal(ModalType.NONE);
+  const { open: gaslessVoteLoadingModal, close: closeGaslessVoteLoadingModal } = useDecentModal(
+    ModalType.GASLESS_VOTE_LOADING,
+  );
 
   const devFeatureFlag = useFeatureFlag('flag_dev');
 
@@ -311,13 +312,13 @@ const useCastVote = (proposalId: string, strategy: Address) => {
         });
 
         bundlerClient.waitForUserOperationReceipt({ hash }).then(() => {
-          closeModal();
+          closeGaslessVoteLoadingModal();
 
           setCastGaslessVotePending(false);
           onSuccess();
         });
       } catch (error: any) {
-        closeModal();
+        closeGaslessVoteLoadingModal();
         setCastGaslessVotePending(false);
 
         if (!devFeatureFlag && error.name === 'UserRejectedRequestError') {
@@ -332,7 +333,7 @@ const useCastVote = (proposalId: string, strategy: Address) => {
       prepareGaslessVoteOperation,
       prepareCastVoteData,
       gaslessVoteLoadingModal,
-      closeModal,
+      closeGaslessVoteLoadingModal,
       devFeatureFlag,
       t,
     ],

--- a/src/hooks/DAO/useSendAssetsActionModal.tsx
+++ b/src/hooks/DAO/useSendAssetsActionModal.tsx
@@ -33,7 +33,7 @@ export default function useSendAssetsActionModal() {
     navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safe.address));
   };
 
-  const openSendAssetsModal = useDecentModal(ModalType.SEND_ASSETS, {
+  const { open: openSendAssetsModal } = useDecentModal(ModalType.SEND_ASSETS, {
     onSubmit: sendAssetsAction,
     submitButtonText: t('submitProposal', { ns: 'modals' }),
   });

--- a/src/hooks/useUnsavedChangesBlocker.ts
+++ b/src/hooks/useUnsavedChangesBlocker.ts
@@ -14,7 +14,7 @@ export function useUnsavedChangesBlocker({
 }: UseUnsavedBlockerOptions): void {
   const blocker = useBlocker(when);
 
-  const openModal = useDecentModal(ModalType.WARN_UNSAVED_CHANGES, {
+  const { open: openModal } = useDecentModal(ModalType.WARN_UNSAVED_CHANGES, {
     discardChanges: () => {
       if (blocker.state === 'blocked' && blocker.proceed) {
         blocker.proceed();

--- a/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
+++ b/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
@@ -102,7 +102,7 @@ export function SafeProposalTemplatesPage() {
     navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safeAddress));
   };
 
-  const openAirdropModal = useDecentModal(ModalType.AIRDROP, {
+  const { open: openAirdropModal } = useDecentModal(ModalType.AIRDROP, {
     onSubmit: handleAirdropSubmit,
     submitButtonText: tModals('submitProposal'),
   });

--- a/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
+++ b/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
@@ -38,7 +38,9 @@ export function AddCreateProposalPermissionModal({
   } = useDAOStore({ daoKey });
   const azoriusGovernance = governance as AzoriusGovernance;
 
-  const openConfirmDeleteStrategyModal = useDecentModal(ModalType.CONFIRM_DELETE_STRATEGY);
+  const { open: openConfirmDeleteStrategyModal } = useDecentModal(
+    ModalType.CONFIRM_DELETE_STRATEGY,
+  );
 
   const { values, setFieldValue } = formikContext;
   const { permissions: permissionsEdits } = values;

--- a/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsCreateProposal.tsx
@@ -77,8 +77,10 @@ export function SafePermissionsCreateProposal() {
     node: { safe },
   } = useDAOStore({ daoKey });
   const azoriusGovernance = governance as AzoriusGovernance;
-  const openSelectAddPermissionModal = useDecentModal(ModalType.ADD_PERMISSION);
-  const openConfirmDeleteStrategyModal = useDecentModal(ModalType.CONFIRM_DELETE_STRATEGY);
+  const { open: openSelectAddPermissionModal } = useDecentModal(ModalType.ADD_PERMISSION);
+  const { open: openConfirmDeleteStrategyModal } = useDecentModal(
+    ModalType.CONFIRM_DELETE_STRATEGY,
+  );
   const { addAction, resetActions } = useProposalActionsStore();
 
   const [proposerThreshold, setProposerThreshold] = useState<BigIntValuePair>({

--- a/src/pages/dao/settings/permissions/SafePermissionsSettingsContent.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsSettingsContent.tsx
@@ -39,7 +39,7 @@ export function SafePermissionsSettingsContent() {
 
   const formikContext = useFormikContext<SafeSettingsEdits>();
 
-  const openAddCreateProposalPermissionModal = useDecentModal(
+  const { open: openAddCreateProposalPermissionModal } = useDecentModal(
     ModalType.ADD_CREATE_PROPOSAL_PERMISSION,
     {
       formikContext,
@@ -47,11 +47,11 @@ export function SafePermissionsSettingsContent() {
     },
   );
 
-  const openAddPermissionModal = useDecentModal(ModalType.ADD_PERMISSION, {
+  const { open: openAddPermissionModal } = useDecentModal(ModalType.ADD_PERMISSION, {
     openAddCreateProposalPermissionModal,
   });
 
-  const openCreateProposalPermissionModal = useDecentModal(
+  const { open: openCreateProposalPermissionModal } = useDecentModal(
     ModalType.ADD_CREATE_PROPOSAL_PERMISSION,
     {
       formikContext,

--- a/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
@@ -39,7 +39,7 @@ export function SafePermissionsSettingsPage() {
   const [searchParams] = useSearchParams();
   const votingStrategyAddress = searchParams.get('votingStrategy');
 
-  const openAddPermissionModal = useDecentModal(ModalType.ADD_PERMISSION);
+  const { open: openAddPermissionModal } = useDecentModal(ModalType.ADD_PERMISSION);
 
   if (isMobile && votingStrategyAddress) {
     return <Outlet />;

--- a/src/pages/dao/treasury/SafeTreasuryPage.tsx
+++ b/src/pages/dao/treasury/SafeTreasuryPage.tsx
@@ -42,7 +42,7 @@ export function SafeTreasuryPage() {
   const showLoadMoreTransactions = totalTransfers > shownTransactions && shownTransactions < 100;
   const { openSendAssetsModal } = useSendAssetsActionModal();
   const safeAddress = safe?.address;
-  const openDappBrowserModal = useDecentModal(ModalType.DAPP_BROWSER, {
+  const { open: openDappBrowserModal } = useDecentModal(ModalType.DAPP_BROWSER, {
     appUrl: 'https://swap.cow.fi',
   });
 


### PR DESCRIPTION
While re-working the modal experience, I did not like the way ModalType.NONE was being shoehorned into a "close modal" functionality. This has led to scenarios where visually there's no modal on-screen, but there actually IS one, just invisible -- NONE, thus causing other attempts to open some other modal to simply not work.

I've attempted to fix this in the past by closing the modal in the NONE switch handler. This PR attempts a more comprehensive and explicit fix.

I've completely removed the NONE type, and exposed an explicit `close` function from `useDecentModal`.