### PR TITLE
Hotfix/15.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decent-interface",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "decent-interface",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@amplitude/analytics-browser": "^2.11.1",
         "@chakra-ui/anatomy": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decent-interface",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "dependencies": {
     "@amplitude/analytics-browser": "^2.11.1",

--- a/src/hooks/DAO/proposal/useGetMetadata.ts
+++ b/src/hooks/DAO/proposal/useGetMetadata.ts
@@ -44,7 +44,7 @@ const useGetMultisigMetadata = (proposal: FractalProposal | null | undefined) =>
 
     // find the last transaction in the multiSend batch, which *should* be the metadata
     // transaction, which contains the IPFS hash as its data array
-    const dataDecoded: DataDecoded = JSON.parse(JSON.stringify(proposal.transaction.dataDecoded));
+    const dataDecoded: DataDecoded = JSON.parse(proposal.transaction.dataDecoded);
     const transactions: Transaction[] = dataDecoded.parameters[0]?.valueDecoded;
 
     if (!transactions) return;

--- a/src/hooks/utils/useSafeDecoder.tsx
+++ b/src/hooks/utils/useSafeDecoder.tsx
@@ -49,7 +49,7 @@ export const useSafeDecoder = () => {
       let decoded: DecodedTransaction | DecodedTransaction[];
       try {
         try {
-          const decodedData = await safeAPI.decodeData(data);
+          const decodedData = await safeAPI.decodeData(data, to);
           if (decodedData.parameters && decodedData.method === 'multiSend') {
             const internalTransactionsMap = new Map<number, DecodedTransaction>();
             parseMultiSendTransactions(internalTransactionsMap, decodedData.parameters);

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -388,16 +388,16 @@ class EnhancedSafeApiKit {
     throw new Error('Failed to proposeTransaction()');
   }
 
-  async decodeData(data: string): Promise<any> {
+  async decodeData(data: string, to: string): Promise<any> {
     try {
       const body = {
-        data: data,
+        data,
+        to,
       };
       const value = await axios.post(`${this.safeClientBaseUrl}/data-decoder`, body, {
         headers: {
           accept: 'application/json',
         },
-        timeout: 1000,
       });
 
       return value.data;

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -1,5 +1,4 @@
 import { abis } from '@fractal-framework/fractal-contracts';
-import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import {
   Address,
   GetContractEventsReturnType,
@@ -311,15 +310,16 @@ export const parseMultiSendTransactions = (
 };
 
 export const parseDecodedData = (
-  multiSigTransaction: SafeMultisigTransactionResponse,
+  to: string,
+  value: string,
+  dataDecoded: DataDecoded,
   isMultiSigTransaction: boolean,
 ): DecodedTransaction[] => {
   const eventTransactionMap = new Map<number, any>();
-  const dataDecoded = multiSigTransaction.dataDecoded as any as DataDecoded;
   if (dataDecoded && isMultiSigTransaction) {
     const decodedTransaction: DecodedTransaction = {
-      target: getAddress(multiSigTransaction.to),
-      value: multiSigTransaction.value,
+      target: getAddress(to),
+      value,
       function: dataDecoded.method,
       parameterTypes: dataDecoded.parameters ? dataDecoded.parameters.map(p => p.type) : [],
       parameterValues: dataDecoded.parameters


### PR DESCRIPTION
So discovered that Safe's Api has updated its multsig-transactions and data-decoder routes

multsig-transactions no longer returns the dataDecoded property in its returns, You must secondly request this information.

data-decoder route has updated, or maybe we were just missing it, but is suppose to include the to value in the body of the post request, this was missing, not sure why/how this was working before or sometimes without it, as per the docs.