### PR TITLE
`[ENG-1074]` Allow for searching with terms that include spaces

### DIFF
--- a/src/components/ui/menus/DAOSearch/index.tsx
+++ b/src/components/ui/menus/DAOSearch/index.tsx
@@ -131,7 +131,7 @@ export function DAOSearch() {
                 size="baseAddonLeft"
                 w="full"
                 placeholder={t('searchDAOPlaceholder')}
-                onChange={e => setLocalInput(e.target.value.trim())}
+                onChange={e => setLocalInput(e.target.value)}
                 value={localInput}
                 spellCheck="false"
                 autoCapitalize="none"


### PR DESCRIPTION
### Summary

- Not to trim DAOSearch input which forbids space.

### Screenshot

<img width="369" alt="image" src="https://github.com/user-attachments/assets/ae1d4a48-c6d0-4c38-90fa-8ee1a5bf300d" />
