### PR TITLE
Fix inconsistent proposer threshold bigint display

### DIFF
--- a/src/pages/dao/settings/permissions/SafePermissionsSettingsContent.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsSettingsContent.tsx
@@ -56,7 +56,7 @@ export function SafePermissionsSettingsContent() {
   }
 
   const editedProposerThreshold =
-    formikContext.values.permissions?.proposerThreshold?.bigintValue?.toString();
+    formikContext.values.permissions?.proposerThreshold?.value?.toString();
 
   const proposerThresholdValue =
     editedProposerThreshold || azoriusGovernance.votingStrategy?.proposerThreshold?.formatted;


### PR DESCRIPTION
Whoopsies. I know I tested this, so I must've fat-finger-changed that variable just before pushing the original PR.

Unedited:
<img width="274" alt="Screenshot 2025-06-03 at 17 47 15" src="https://github.com/user-attachments/assets/1aeea824-a0d6-420b-9fda-234062ec5e13" />

Edited (current):
<img width="594" alt="Screenshot 2025-06-03 at 17 48 01" src="https://github.com/user-attachments/assets/4b15ade0-1ae4-4c65-82d5-891603db5d2b" />

Edited (fixed):
<img width="412" alt="Screenshot 2025-06-03 at 17 47 33" src="https://github.com/user-attachments/assets/7dd18509-8a64-4f3e-aa5c-b3d39d6a3d86" />

