### PR TITLE
Fix Report Bug button overlapping settings modal action buttons

### DIFF
--- a/src/components/ui/modals/ModalBase.tsx
+++ b/src/components/ui/modals/ModalBase.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../constants/common';
 import Divider from '../utils/Divider';
 
-export type ModalBaseSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'max';
+export type ModalBaseSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '6xl' | 'max';
 
 export type ModalContentStyle = {
   backgroundColor?: string;

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -435,7 +435,7 @@ const getModalData = (args: {
           closeAllModals={closeAll}
         />
       );
-      modalSize = 'max';
+      modalSize = '6xl';
       modalContentStyle = {
         backgroundColor: NEUTRAL_2_50_TRANSPARENT,
         padding: '0',

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { Button, Flex, Text } from '@chakra-ui/react';
 import { abis } from '@fractal-framework/fractal-contracts';
 import { Formik, Form, useFormikContext } from 'formik';
 import { useState } from 'react';
@@ -164,10 +164,10 @@ export function SafeSettingsModal({
       <Flex
         flexDirection="row"
         justifyContent="flex-end"
-        mt="1rem"
+        my="1rem"
         mr={4}
         alignItems="center"
-        alignSelf="center"
+        alignSelf="flex-end"
         alignContent="center"
         gap="0.5rem"
       >
@@ -1048,9 +1048,9 @@ export function SafeSettingsModal({
       }}
     >
       <Form>
-        <Box
+        <Flex
           flexDirection="column"
-          height="85vh"
+          height="90vh"
         >
           <Flex
             flex="1"
@@ -1064,7 +1064,7 @@ export function SafeSettingsModal({
 
           <Divider />
           <ActionButtons />
-        </Box>
+        </Flex>
       </Form>
     </Formik>
   );


### PR DESCRIPTION
Updated ModalBase and SafeSettingsModal components to support new modal size and improve layout

- Added '6xl' option to ModalBaseSize type. Similar size as `max`, but much thinner to get outta the way of the bug report button.
- Updated modal size in ModalProvider to '6xl'.
- Refactored SafeSettingsModal layout: changed Box to Flex, adjusted height to '90vh', and modified margin properties for better alignment.