### PR TITLE
`[ENG-1148]` Fix first load issues

### DIFF
--- a/src/hooks/useNetworkPublicClient.ts
+++ b/src/hooks/useNetworkPublicClient.ts
@@ -1,17 +1,27 @@
 import { useMemo } from 'react';
 import { createPublicClient, http } from 'viem';
-import { useNetworkConfigStore } from '../providers/NetworkConfig/useNetworkConfigStore';
+import {
+  getNetworkConfig,
+  useNetworkConfigStore,
+} from '../providers/NetworkConfig/useNetworkConfigStore';
+import { getChainIdFromPrefix } from '../utils/url';
+import { useCurrentDAOKey } from './DAO/useCurrentDAOKey';
 
 export default function useNetworkPublicClient() {
-  const { chain, rpcEndpoint } = useNetworkConfigStore();
+  const { addressPrefix: urlAddressPrefix } = useCurrentDAOKey();
+  const { addressPrefix, chain, rpcEndpoint } = useNetworkConfigStore();
 
-  const publicClient = useMemo(
-    () =>
-      createPublicClient({
-        chain,
-        transport: http(rpcEndpoint),
-      }),
-    [chain, rpcEndpoint],
-  );
+  const publicClient = useMemo(() => {
+    if (urlAddressPrefix && urlAddressPrefix !== addressPrefix) {
+      return createPublicClient({
+        chain: getNetworkConfig(getChainIdFromPrefix(urlAddressPrefix)).chain,
+        transport: http(getNetworkConfig(getChainIdFromPrefix(urlAddressPrefix)).rpcEndpoint),
+      });
+    }
+    return createPublicClient({
+      chain,
+      transport: http(rpcEndpoint),
+    });
+  }, [chain, rpcEndpoint, urlAddressPrefix, addressPrefix]);
   return publicClient;
 }


### PR DESCRIPTION
So this solves a few different problems (I'll try to find the tickets if they exist). But basically in the first second the app loads in. its default network configuration is set to mainnet (currently no way around it unless we allow the network to be `undefined` for a second while the URL is checked. 

These two updates allows the information gathers (publicClient and safeAPI) to settle on the correct network when refreshing or navigating straight to a DAO that isn't on `mainnet`