### PR TITLE
`ENG-1137 ~ Release`: [FIX] Option to refill paymaster using DAO treasury bypasses settings modal

### DIFF
--- a/public/locales/en/gaslessVoting.json
+++ b/public/locales/en/gaslessVoting.json
@@ -37,5 +37,6 @@
   "recipientAddressRequired": "Recipient address is required",
   "withdrawGasAction": "Withdraw {{amount}} {{symbol}} from the paymaster",
   "recipientAddress": "Recipient Address",
-  "enterRecipientAddress": "Enter recipient address"
+  "enterRecipientAddress": "Enter recipient address",
+  "amountExceedsAvailableBalance": "Insufficient balance"
 }

--- a/public/locales/en/gaslessVoting.json
+++ b/public/locales/en/gaslessVoting.json
@@ -39,6 +39,6 @@
   "recipientAddress": "Recipient Address",
   "enterRecipientAddress": "Enter recipient address",
   "amountExceedsAvailableBalance": "Insufficient balance",
-  "withdrawingGas": "Withdrawing {{amount}} {{symbol}}",
+  "withdrawingGas": "Withdrawing {{amount}} {{symbol}} to {{recipient}}",
   "depositingGas": "Depositing {{amount}} {{symbol}}"
 }

--- a/public/locales/en/gaslessVoting.json
+++ b/public/locales/en/gaslessVoting.json
@@ -38,5 +38,7 @@
   "withdrawGasAction": "Withdraw {{amount}} {{symbol}} from the paymaster",
   "recipientAddress": "Recipient Address",
   "enterRecipientAddress": "Enter recipient address",
-  "amountExceedsAvailableBalance": "Insufficient balance"
+  "amountExceedsAvailableBalance": "Insufficient balance",
+  "withdrawingGas": "Withdrawing {{amount}} {{symbol}}",
+  "depositingGas": "Depositing {{amount}} {{symbol}}"
 }

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, HStack, Image, Switch, Text } from '@chakra-ui/react';
+import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { usePaymasterDepositInfo } from '../../hooks/DAO/accountAbstraction/usePaymasterDepositInfo';
@@ -9,6 +10,7 @@ import { useDAOStore } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { formatCoin } from '../../utils';
 import { ModalType } from '../ui/modals/ModalProvider';
+import { SafeSettingsEdits } from '../ui/modals/SafeSettingsModal';
 import { useDecentModal } from '../ui/modals/useDecentModal';
 import Divider from '../ui/utils/Divider';
 
@@ -91,6 +93,7 @@ function GaslessVotingToggleContent({
 export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) {
   const { t } = useTranslation('gaslessVoting');
   const { bundlerMinimumStake, nativeTokenIcon } = useNetworkConfigStore();
+  const settingsModalFormikContext = useFormikContext<SafeSettingsEdits>();
 
   const publicClient = useNetworkPublicClient();
   const nativeCurrency = publicClient.chain.nativeCurrency;
@@ -101,9 +104,12 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
   } = useDAOStore({ daoKey });
   const { depositInfo } = usePaymasterDepositInfo();
 
-  const { open: openWithdrawGasModal } = useDecentModal(ModalType.WITHDRAW_GAS);
-
-  const { open: openRefillGasModal } = useDecentModal(ModalType.REFILL_GAS);
+  const { open: openWithdrawGasModal } = useDecentModal(ModalType.WITHDRAW_GAS, {
+    formikContext: settingsModalFormikContext,
+  });
+  const { open: openRefillGasModal } = useDecentModal(ModalType.REFILL_GAS, {
+    formikContext: settingsModalFormikContext,
+  });
 
   const gaslessFeatureEnabled = useFeatureFlag('flag_gasless_voting');
   const gaslessStakingEnabled = gaslessFeatureEnabled && bundlerMinimumStake !== undefined;

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -108,7 +108,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
     setFieldValue: settingsModalFormikContext.setFieldValue,
   });
   const { open: openRefillGasModal } = useDecentModal(ModalType.REFILL_GAS, {
-    formikContext: settingsModalFormikContext,
+    setFieldValue: settingsModalFormikContext.setFieldValue,
   });
 
   const gaslessFeatureEnabled = useFeatureFlag('flag_gasless_voting');

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, HStack, IconButton, Image, Switch, Text } from '@chakra-ui/react';
-import { TrashSimple, X } from '@phosphor-icons/react';
+import { TrashSimple } from '@phosphor-icons/react';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { isAddress } from 'viem';
@@ -41,7 +41,10 @@ function WithdrawingGasComponent() {
       : recipientInput;
 
   return (
-    <Flex gap="0.5rem">
+    <Flex
+      gap="0.5rem"
+      alignItems="center"
+    >
       <Text>
         {t('withdrawingGas', {
           amount: withdrawingGasAmount,
@@ -50,16 +53,14 @@ function WithdrawingGasComponent() {
         })}
       </Text>
       <IconButton
-        aria-label="remove NFT from the list"
-        icon={<X size="24" />}
+        aria-label="Remove gas withdrawal action"
+        icon={<TrashSimple />}
         variant="unstyled"
         minWidth="auto"
-        color="color-red-100"
+        color="color-error-500"
         sx={{ '&:disabled:hover': { color: 'inherit', opacity: 0.4 } }}
         type="button"
         onClick={() => setFieldValue('paymasterGasTank.withdraw', undefined)}
-        mt="-0.25rem"
-        ml="0.5rem"
       />
     </Flex>
   );
@@ -89,7 +90,7 @@ function DepositingGasComponent() {
         })}
       </Text>
       <IconButton
-        aria-label="remove NFT from the list"
+        aria-label="Remove gas deposit action"
         icon={<TrashSimple />}
         variant="unstyled"
         minWidth="auto"

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -2,11 +2,13 @@ import { Box, Button, Flex, HStack, IconButton, Image, Switch, Text } from '@cha
 import { TrashSimple, X } from '@phosphor-icons/react';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { isAddress } from 'viem';
 import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { usePaymasterDepositInfo } from '../../hooks/DAO/accountAbstraction/usePaymasterDepositInfo';
 import { useCurrentDAOKey } from '../../hooks/DAO/useCurrentDAOKey';
 import useNetworkPublicClient from '../../hooks/useNetworkPublicClient';
 import { useCanUserCreateProposal } from '../../hooks/utils/useCanUserSubmitProposal';
+import { createAccountSubstring } from '../../hooks/utils/useGetAccountName';
 import { useDAOStore } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { useSettingsFormStore } from '../../store/settings/useSettingsFormStore';
@@ -32,12 +34,19 @@ function WithdrawingGasComponent() {
 
   if (!withdrawingGasAmount || paymasterGasTankWithdrawError !== undefined) return null;
 
+  const recipientInput = values?.paymasterGasTank?.withdraw?.recipientAddress;
+  const recipient =
+    recipientInput !== undefined && isAddress(recipientInput)
+      ? createAccountSubstring(recipientInput)
+      : recipientInput;
+
   return (
     <Flex gap="0.5rem">
       <Text>
         {t('withdrawingGas', {
           amount: withdrawingGasAmount,
           symbol: nativeCurrency.symbol,
+          recipient,
         })}
       </Text>
       <IconButton

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -9,9 +9,10 @@ import useNetworkPublicClient from '../../hooks/useNetworkPublicClient';
 import { useCanUserCreateProposal } from '../../hooks/utils/useCanUserSubmitProposal';
 import { useDAOStore } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
+import { useSettingsFormStore } from '../../store/settings/useSettingsFormStore';
 import { formatCoin } from '../../utils';
 import { ModalType } from '../ui/modals/ModalProvider';
-import { SafeSettingsEdits, SafeSettingsFormikErrors } from '../ui/modals/SafeSettingsModal';
+import { SafeSettingsEdits } from '../ui/modals/SafeSettingsModal';
 import { useDecentModal } from '../ui/modals/useDecentModal';
 import Divider from '../ui/utils/Divider';
 
@@ -23,13 +24,13 @@ interface GaslessVotingToggleProps {
 function WithdrawingGasComponent() {
   const { t } = useTranslation('gaslessVoting');
   const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
-  const { errors } = useFormikContext<SafeSettingsFormikErrors>();
-  const { paymasterGasTank: paymasterGasTankErrors } = errors as SafeSettingsFormikErrors;
+  const { formErrors } = useSettingsFormStore();
+  const paymasterGasTankWithdrawError = formErrors?.paymasterGasTank?.withdraw;
 
   const withdrawingGasAmount = values?.paymasterGasTank?.withdraw?.amount?.value;
   const nativeCurrency = useNetworkPublicClient().chain.nativeCurrency;
 
-  if (!withdrawingGasAmount || paymasterGasTankErrors?.withdraw !== undefined) return null;
+  if (!withdrawingGasAmount || paymasterGasTankWithdrawError !== undefined) return null;
 
   return (
     <Flex gap="0.5rem">
@@ -58,13 +59,14 @@ function WithdrawingGasComponent() {
 function DepositingGasComponent() {
   const { t } = useTranslation('gaslessVoting');
   const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
-  const { errors } = useFormikContext<SafeSettingsFormikErrors>();
-  const { paymasterGasTank: paymasterGasTankErrors } = errors as SafeSettingsFormikErrors;
+
+  const { formErrors } = useSettingsFormStore();
+  const paymasterGasTankDepositError = formErrors?.paymasterGasTank?.deposit?.amount;
 
   const depositingGasAmount = values?.paymasterGasTank?.deposit?.amount?.value;
   const nativeCurrency = useNetworkPublicClient().chain.nativeCurrency;
 
-  if (!depositingGasAmount || paymasterGasTankErrors?.deposit?.amount !== undefined) return null;
+  if (!depositingGasAmount || paymasterGasTankDepositError !== undefined) return null;
 
   return (
     <Flex

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -105,7 +105,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
   const { depositInfo } = usePaymasterDepositInfo();
 
   const { open: openWithdrawGasModal } = useDecentModal(ModalType.WITHDRAW_GAS, {
-    formikContext: settingsModalFormikContext,
+    setFieldValue: settingsModalFormikContext.setFieldValue,
   });
   const { open: openRefillGasModal } = useDecentModal(ModalType.REFILL_GAS, {
     formikContext: settingsModalFormikContext,

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -76,7 +76,12 @@ function DepositingGasComponent() {
   const depositingGasAmount = values?.paymasterGasTank?.deposit?.amount?.value;
   const nativeCurrency = useNetworkPublicClient().chain.nativeCurrency;
 
-  if (!depositingGasAmount || paymasterGasTankDepositError !== undefined) return null;
+  if (
+    values?.paymasterGasTank?.deposit?.isDirectDeposit ||
+    !depositingGasAmount ||
+    paymasterGasTankDepositError !== undefined
+  )
+    return null;
 
   return (
     <Flex
@@ -220,6 +225,12 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
     false,
   );
 
+  const paymasterGasTankEdits = values?.paymasterGasTank;
+
+  const showWithdrawAndDepositButtons =
+    paymasterGasTankEdits?.deposit?.isDirectDeposit ||
+    (paymasterGasTankEdits?.withdraw === undefined && paymasterGasTankEdits?.deposit === undefined);
+
   return (
     <Flex
       display="flex"
@@ -276,25 +287,24 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
             <Flex gap="0.5rem">
               <WithdrawingGasComponent />
               <DepositingGasComponent />
-              {values?.paymasterGasTank?.withdraw === undefined &&
-                values?.paymasterGasTank?.deposit === undefined && (
-                  <>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={openWithdrawGasModal}
-                    >
-                      {t('withdrawGas')}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={openRefillGasModal}
-                    >
-                      {t('addGas')}
-                    </Button>
-                  </>
-                )}
+              {showWithdrawAndDepositButtons && (
+                <>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={openWithdrawGasModal}
+                  >
+                    {t('withdrawGas')}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={openRefillGasModal}
+                  >
+                    {t('addGas')}
+                  </Button>
+                </>
+              )}
             </Flex>
           </Flex>
         </>

--- a/src/components/ProposalBuilder/ProposalActionCard.tsx
+++ b/src/components/ProposalBuilder/ProposalActionCard.tsx
@@ -244,8 +244,22 @@ export function ProposalActionCard({
           alignItems="center"
         >
           <Icon
-            as={isAddAction ? CheckSquare : isEditAction ? PencilWithLineIcon : Trash}
-            color={isEditAction || isAddAction ? 'color-neutral-300' : 'color-error-400'}
+            as={
+              isAddAction
+                ? CheckSquare
+                : isEditAction
+                  ? PencilWithLineIcon
+                  : isDeleteAction
+                    ? Trash
+                    : CheckSquare
+            }
+            color={
+              isEditAction || isAddAction
+                ? 'color-neutral-300'
+                : isDeleteAction
+                  ? 'color-error-400'
+                  : 'color-neutral-300'
+            }
           />
           {action.content}
         </Flex>

--- a/src/components/SafeSettings/SettingsNavigation.tsx
+++ b/src/components/SafeSettings/SettingsNavigation.tsx
@@ -233,7 +233,7 @@ export function SettingsNavigation({
               onSettingsNavigationClick(<SafeGeneralSettingsPage />);
               setCurrentItem('general');
             }}
-            hasEdits={values.general !== undefined}
+            hasEdits={values.general !== undefined || values.paymasterGasTank !== undefined}
           />
           <SettingsNavigationItem
             title={t('daoSettingsGovernance')}

--- a/src/components/SafeSettings/SettingsNavigation.tsx
+++ b/src/components/SafeSettings/SettingsNavigation.tsx
@@ -233,7 +233,11 @@ export function SettingsNavigation({
               onSettingsNavigationClick(<SafeGeneralSettingsPage />);
               setCurrentItem('general');
             }}
-            hasEdits={values.general !== undefined || values.paymasterGasTank !== undefined}
+            hasEdits={
+              values.general !== undefined ||
+              (values.paymasterGasTank !== undefined &&
+                !values.paymasterGasTank.deposit?.isDirectDeposit)
+            }
           />
           <SettingsNavigationItem
             title={t('daoSettingsGovernance')}

--- a/src/components/ui/forms/BigIntInput.tsx
+++ b/src/components/ui/forms/BigIntInput.tsx
@@ -36,6 +36,7 @@ export interface BigIntInputProps
  */
 export function BigIntInput({
   // @todo `value` can most likely either be removed, or be used for what `parentFormikValue` is currently being used for. Currently it works as nothing more than an initial value.
+  // https://linear.app/decent-labs/issue/ENG-1158/remove-bigintinputvalue-not-being-used
   value,
   onChange,
   decimalPlaces = 18,
@@ -149,7 +150,11 @@ export function BigIntInput({
   // if the parent Formik value prop changes, need to update the value
   useEffect(() => {
     // If parentFormikValue is set to undefined, then the input should be blank
-    if (parentFormikValue === undefined) {
+    if (
+      parentFormikValue === undefined ||
+      parentFormikValue.bigintValue === undefined ||
+      parentFormikValue.value === ''
+    ) {
       setInputValue('');
       return;
     }

--- a/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
@@ -74,9 +74,7 @@ export function RefillGasTankModal({
         ...formErrors,
         paymasterGasTank: {
           ...formErrors?.paymasterGasTank,
-          deposit: {
-            amount: undefined,
-          },
+          deposit: undefined,
         },
       });
     }
@@ -145,7 +143,6 @@ export function RefillGasTankModal({
             parentFormikValue={values.amount}
             decimalPlaces={balance?.decimals || 0}
             placeholder="0"
-            maxValue={!isDirectDeposit ? balance?.value || 0n : undefined}
             isInvalid={overDraft || paymasterGasTankErrors.deposit?.amount !== undefined}
             errorBorderColor="color-error-500"
             autoFocus
@@ -184,7 +181,10 @@ export function RefillGasTankModal({
       >
         <Button
           variant="secondary"
-          onClick={close}
+          onClick={() => {
+            setFieldValue('paymasterGasTank.deposit', undefined);
+            close();
+          }}
         >
           {t('cancel', { ns: 'common' })}
         </Button>

--- a/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
@@ -139,8 +139,8 @@ export function RefillGasTankModal({
         >
           <BigIntInput
             value={values.amount?.bigintValue}
-            onChange={value => {
-              setFieldValue('paymasterGasTank.deposit.amount', value);
+            onChange={inputValue => {
+              setFieldValue('paymasterGasTank.deposit.amount', inputValue);
             }}
             parentFormikValue={values.amount}
             decimalPlaces={balance?.decimals || 0}

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -1,10 +1,9 @@
 import { Box, Button, CloseButton, Flex, Text } from '@chakra-ui/react';
-import { Field, FieldAttributes, FieldProps, useFormikContext } from 'formik';
+import { FormikContextType } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { usePaymasterDepositInfo } from '../../../../hooks/DAO/accountAbstraction/usePaymasterDepositInfo';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
 import { useDAOStore } from '../../../../providers/App/AppProvider';
-import { BigIntValuePair } from '../../../../types';
 import { formatCoinUnits } from '../../../../utils/numberFormats';
 import { BigIntInput } from '../../forms/BigIntInput';
 import { AddressInput } from '../../forms/EthAddressInput';
@@ -12,7 +11,13 @@ import LabelWrapper from '../../forms/LabelWrapper';
 import { AssetSelector } from '../../utils/AssetSelector';
 import { SafeSettingsEdits, SafeSettingsFormikErrors } from '../SafeSettingsModal';
 
-export function WithdrawGasTankModal({ close }: { close: () => void }) {
+export function WithdrawGasTankModal({
+  close,
+  formikContext,
+}: {
+  close: () => void;
+  formikContext: FormikContextType<SafeSettingsEdits>;
+}) {
   const { depositInfo } = usePaymasterDepositInfo();
 
   const { t } = useTranslation('gaslessVoting');
@@ -22,8 +27,8 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
     node: { safe },
   } = useDAOStore({ daoKey });
 
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
-  const { errors } = useFormikContext<SafeSettingsFormikErrors>();
+  const { values, setFieldValue } = formikContext;
+  const { errors } = formikContext;
 
   const paymasterGasTankErrors = (errors as SafeSettingsFormikErrors).paymasterGasTank;
 
@@ -68,23 +73,18 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
           justify="space-between"
           align="flex-start"
         >
-          <Field name="inputAmount">
-            {({ field }: FieldAttributes<FieldProps<BigIntValuePair | undefined>>) => (
-              <LabelWrapper>
-                <BigIntInput
-                  {...field}
-                  value={field.value?.bigintValue}
-                  onChange={value => {
-                    setFieldValue('paymasterGasTank.withdraw.amount', value);
-                  }}
-                  parentFormikValue={values.paymasterGasTank?.withdraw?.amount}
-                  placeholder="0"
-                  isInvalid={overDraft}
-                  errorBorderColor="color-error-500"
-                />
-              </LabelWrapper>
-            )}
-          </Field>
+          <LabelWrapper>
+            <BigIntInput
+              value={values.paymasterGasTank?.withdraw?.amount?.bigintValue}
+              onChange={value => {
+                setFieldValue('paymasterGasTank.withdraw.amount', value);
+              }}
+              parentFormikValue={values.paymasterGasTank?.withdraw?.amount}
+              placeholder="0"
+              isInvalid={overDraft}
+              errorBorderColor="color-error-500"
+            />
+          </LabelWrapper>
 
           <Flex
             flexDirection="column"
@@ -115,16 +115,15 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
         >
           {t('recipientAddress')}
         </Text>
-        <Field name="recipientAddress">
-          {({ field }: FieldAttributes<FieldProps<string | undefined>>) => (
-            <LabelWrapper errorMessage={paymasterGasTankErrors?.withdraw?.recipientAddress}>
-              <AddressInput
-                {...field}
-                isInvalid={!!paymasterGasTankErrors?.withdraw?.recipientAddress}
-              />
-            </LabelWrapper>
-          )}
-        </Field>
+        <LabelWrapper errorMessage={paymasterGasTankErrors?.withdraw?.recipientAddress}>
+          <AddressInput
+            value={values.paymasterGasTank?.withdraw?.recipientAddress}
+            onChange={value => {
+              setFieldValue('paymasterGasTank.withdraw.recipientAddress', value);
+            }}
+            isInvalid={!!paymasterGasTankErrors?.withdraw?.recipientAddress}
+          />
+        </LabelWrapper>
         <Button
           variant="tertiary"
           size="sm"

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -1,10 +1,8 @@
 import { Box, Button, CloseButton, Flex, Text } from '@chakra-ui/react';
-import { FormikContextType } from 'formik';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePaymasterDepositInfo } from '../../../../hooks/DAO/accountAbstraction/usePaymasterDepositInfo';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
-import { useValidationAddress } from '../../../../hooks/schemas/common/useValidationAddress';
 import { useDAOStore } from '../../../../providers/App/AppProvider';
 import { useSettingsFormStore } from '../../../../store/settings/useSettingsFormStore';
 import { formatCoinUnits } from '../../../../utils/numberFormats';
@@ -12,14 +10,14 @@ import { BigIntInput } from '../../forms/BigIntInput';
 import { AddressInput } from '../../forms/EthAddressInput';
 import LabelWrapper from '../../forms/LabelWrapper';
 import { AssetSelector } from '../../utils/AssetSelector';
-import { SafeSettingsEdits } from '../SafeSettingsModal';
 
-type ValidationErrors = {
-  amount?: string;
-  recipientAddress?: string;
-};
-
-function WithdrawGasTankModalContent({ close }: { close: () => void }) {
+export function WithdrawGasTankModal({
+  close,
+  setFieldValue,
+}: {
+  close: () => void;
+  setFieldValue: (field: string, value: any) => void;
+}) {
   const { depositInfo } = usePaymasterDepositInfo();
   const { t } = useTranslation('gaslessVoting');
   const { daoKey } = useCurrentDAOKey();
@@ -27,80 +25,24 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
     node: { safe },
   } = useDAOStore({ daoKey });
 
-  const { formState, updateFormState } = useSettingsFormStore();
-  const values = formState ?? {};
-  const [paymasterGasTankErrors, setPaymasterGasTankErrors] = useState<ValidationErrors>({});
-  const { addressValidationTest } = useValidationAddress();
+  const { formState, formErrors } = useSettingsFormStore();
+  const values = formState?.paymasterGasTank?.withdraw ?? {};
+  const paymasterGasTankErrors = formErrors?.paymasterGasTank ?? {};
 
   // Clean up withdraw object if both fields are empty
   useEffect(() => {
-    if (
-      values.paymasterGasTank?.withdraw &&
-      !values.paymasterGasTank.withdraw.amount &&
-      !values.paymasterGasTank.withdraw.recipientAddress
-    ) {
-      updateFormState({
-        paymasterGasTank: {
-          ...values.paymasterGasTank,
-          withdraw: undefined,
-        },
-      });
+    if (values.amount === undefined && values.recipientAddress === undefined) {
+      setFieldValue('paymasterGasTank.withdraw', undefined);
     }
-  }, [values.paymasterGasTank?.withdraw, updateFormState, values.paymasterGasTank]);
+  }, [values.amount, values.recipientAddress, setFieldValue]);
 
-  const inputBigint = values.paymasterGasTank?.withdraw?.amount?.bigintValue;
+  const inputBigint = values.amount?.bigintValue;
   const inputBigintIsZero = inputBigint !== undefined ? inputBigint === 0n : undefined;
   const isSubmitDisabled =
-    !values.paymasterGasTank?.withdraw?.amount ||
+    !values.amount ||
     inputBigintIsZero ||
-    paymasterGasTankErrors.amount !== undefined ||
-    paymasterGasTankErrors.recipientAddress !== undefined;
-
-  const validateAmount = (amount: { bigintValue: bigint; value: string } | undefined) => {
-    if (!amount) return;
-    if (amount.bigintValue === 0n) return 'Amount must be greater than 0';
-    if (amount.bigintValue > (depositInfo?.balance ?? 0n))
-      return 'Amount exceeds available balance';
-    return;
-  };
-
-  const validateRecipientAddress = async (address: string | undefined) => {
-    if (!address) return 'Recipient address is required';
-    try {
-      const isValid = await addressValidationTest.test(address);
-      if (!isValid) return 'Invalid address';
-      return;
-    } catch (error) {
-      return 'Invalid address';
-    }
-  };
-
-  const handleFieldUpdate = async (field: string, value: any) => {
-    const [section, subsection, fieldName] = field.split('.');
-    updateFormState({
-      [section]: {
-        ...values[section as keyof SafeSettingsEdits],
-        [subsection]: {
-          ...(values[section as keyof SafeSettingsEdits] as any)?.[subsection],
-          [fieldName]: value,
-        },
-      },
-    } as Partial<SafeSettingsEdits>);
-
-    // Update validation errors
-    if (field === 'paymasterGasTank.withdraw.amount') {
-      setPaymasterGasTankErrors(prev => ({
-        ...prev,
-        amount: validateAmount(value),
-      }));
-    } else if (field === 'paymasterGasTank.withdraw.recipientAddress') {
-      const error = await validateRecipientAddress(value);
-      setPaymasterGasTankErrors(prev => ({
-        ...prev,
-        recipientAddress: error,
-      }));
-    }
-  };
+    paymasterGasTankErrors.withdraw?.amount !== undefined ||
+    paymasterGasTankErrors.withdraw?.recipientAddress !== undefined;
 
   return (
     <Box>
@@ -134,18 +76,14 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
           justify="space-between"
           align="flex-start"
         >
-          <LabelWrapper errorMessage={paymasterGasTankErrors.amount}>
+          <LabelWrapper errorMessage={paymasterGasTankErrors.withdraw?.amount}>
             <BigIntInput
-              value={values.paymasterGasTank?.withdraw?.amount?.bigintValue}
-              onChange={value => {
-                handleFieldUpdate(
-                  'paymasterGasTank.withdraw.amount',
-                  value.value ? value : undefined,
-                );
+              onChange={inputValue => {
+                setFieldValue('paymasterGasTank.withdraw.amount', inputValue);
               }}
-              parentFormikValue={values.paymasterGasTank?.withdraw?.amount}
+              parentFormikValue={values.amount}
               placeholder="0"
-              isInvalid={paymasterGasTankErrors.amount !== undefined}
+              isInvalid={paymasterGasTankErrors.withdraw?.amount !== undefined}
               errorBorderColor="color-error-500"
             />
           </LabelWrapper>
@@ -162,7 +100,7 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
             />
             <Text
               color={
-                paymasterGasTankErrors.amount !== undefined
+                paymasterGasTankErrors.withdraw?.amount !== undefined
                   ? 'color-error-500'
                   : 'color-neutral-300'
               }
@@ -183,16 +121,13 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
         >
           {t('recipientAddress')}
         </Text>
-        <LabelWrapper errorMessage={paymasterGasTankErrors.recipientAddress}>
+        <LabelWrapper errorMessage={paymasterGasTankErrors.withdraw?.recipientAddress}>
           <AddressInput
-            value={values.paymasterGasTank?.withdraw?.recipientAddress}
+            value={values.recipientAddress}
             onChange={e => {
-              handleFieldUpdate('paymasterGasTank.withdraw.recipientAddress', e.target.value);
+              setFieldValue('paymasterGasTank.withdraw.recipientAddress', e.target.value);
             }}
-            isInvalid={
-              values.paymasterGasTank?.withdraw?.recipientAddress !== undefined &&
-              paymasterGasTankErrors.recipientAddress !== undefined
-            }
+            isInvalid={paymasterGasTankErrors.withdraw?.recipientAddress !== undefined}
           />
         </LabelWrapper>
         <Button
@@ -200,7 +135,7 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
           size="sm"
           alignSelf="flex-end"
           onClick={() => {
-            handleFieldUpdate('paymasterGasTank.withdraw.recipientAddress', safe?.address);
+            setFieldValue('paymasterGasTank.withdraw.recipientAddress', safe?.address);
           }}
         >
           {t('toDaoTreasury')}
@@ -215,7 +150,7 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
         <Button
           variant="secondary"
           onClick={() => {
-            handleFieldUpdate('paymasterGasTank.withdraw', undefined);
+            setFieldValue('paymasterGasTank.withdraw', undefined);
             close();
           }}
         >
@@ -224,8 +159,8 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
         <Button
           onClick={close}
           isDisabled={
-            paymasterGasTankErrors.amount !== undefined ||
-            paymasterGasTankErrors.recipientAddress !== undefined ||
+            paymasterGasTankErrors.withdraw?.amount !== undefined ||
+            paymasterGasTankErrors.withdraw?.recipientAddress !== undefined ||
             isSubmitDisabled
           }
         >
@@ -234,13 +169,4 @@ function WithdrawGasTankModalContent({ close }: { close: () => void }) {
       </Flex>
     </Box>
   );
-}
-
-export function WithdrawGasTankModal({
-  close,
-}: {
-  close: () => void;
-  formikContext?: FormikContextType<SafeSettingsEdits>;
-}) {
-  return <WithdrawGasTankModalContent close={close} />;
 }

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -36,12 +36,14 @@ export function WithdrawGasTankModal({
     }
   }, [values.amount, values.recipientAddress, setFieldValue]);
 
-  const inputBigint = values.amount?.bigintValue;
-  const inputBigintIsZero = inputBigint !== undefined ? inputBigint === 0n : undefined;
+  console.log(paymasterGasTankErrors.withdraw?.amount);
+
   const isSubmitDisabled =
     !values.amount ||
-    inputBigintIsZero ||
+    values.amount.bigintValue === undefined ||
+    values.amount.bigintValue === 0n ||
     paymasterGasTankErrors.withdraw?.amount !== undefined ||
+    values.recipientAddress === undefined ||
     paymasterGasTankErrors.withdraw?.recipientAddress !== undefined;
 
   return (

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -36,8 +36,6 @@ export function WithdrawGasTankModal({
     }
   }, [values.amount, values.recipientAddress, setFieldValue]);
 
-  console.log(paymasterGasTankErrors.withdraw?.amount);
-
   const isSubmitDisabled =
     !values.amount ||
     values.amount.bigintValue === undefined ||

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -122,7 +122,7 @@ export type ModalPropsTypes = {
     formikContext: FormikContextType<SafeSettingsEdits>;
   };
   [ModalType.WITHDRAW_GAS]: {
-    formikContext: FormikContextType<SafeSettingsEdits>;
+    setFieldValue: (field: string, value: any) => void;
   };
   [ModalType.GASLESS_VOTE_LOADING]: {};
   [ModalType.GASLESS_VOTE_SUCCESS]: {};
@@ -372,7 +372,12 @@ const getModalData = (args: {
       );
       break;
     case ModalType.WITHDRAW_GAS:
-      modalContent = <WithdrawGasTankModal close={popModal} />;
+      modalContent = (
+        <WithdrawGasTankModal
+          close={popModal}
+          setFieldValue={current.props.setFieldValue}
+        />
+      );
       break;
     case ModalType.GASLESS_VOTE_SUCCESS:
       modalContent = <GaslessVoteSuccessModal close={popModal} />;

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -372,12 +372,7 @@ const getModalData = (args: {
       );
       break;
     case ModalType.WITHDRAW_GAS:
-      modalContent = (
-        <WithdrawGasTankModal
-          close={popModal}
-          formikContext={current.props.formikContext}
-        />
-      );
+      modalContent = <WithdrawGasTankModal close={popModal} />;
       break;
     case ModalType.GASLESS_VOTE_SUCCESS:
       modalContent = <GaslessVoteSuccessModal close={popModal} />;

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -118,8 +118,12 @@ export type ModalPropsTypes = {
     onSubmit: (airdropData: AirdropData) => void;
     submitButtonText: string;
   };
-  [ModalType.REFILL_GAS]: {};
-  [ModalType.WITHDRAW_GAS]: {};
+  [ModalType.REFILL_GAS]: {
+    formikContext: FormikContextType<SafeSettingsEdits>;
+  };
+  [ModalType.WITHDRAW_GAS]: {
+    formikContext: FormikContextType<SafeSettingsEdits>;
+  };
   [ModalType.GASLESS_VOTE_LOADING]: {};
   [ModalType.GASLESS_VOTE_SUCCESS]: {};
   [ModalType.GASLESS_VOTE_FAILED]: {
@@ -360,10 +364,20 @@ const getModalData = (args: {
       );
       break;
     case ModalType.REFILL_GAS:
-      modalContent = <RefillGasTankModal close={popModal} />;
+      modalContent = (
+        <RefillGasTankModal
+          close={popModal}
+          formikContext={current.props.formikContext}
+        />
+      );
       break;
     case ModalType.WITHDRAW_GAS:
-      modalContent = <WithdrawGasTankModal close={popModal} />;
+      modalContent = (
+        <WithdrawGasTankModal
+          close={popModal}
+          formikContext={current.props.formikContext}
+        />
+      );
       break;
     case ModalType.GASLESS_VOTE_SUCCESS:
       modalContent = <GaslessVoteSuccessModal close={popModal} />;

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -119,7 +119,7 @@ export type ModalPropsTypes = {
     submitButtonText: string;
   };
   [ModalType.REFILL_GAS]: {
-    formikContext: FormikContextType<SafeSettingsEdits>;
+    setFieldValue: (field: string, value: any) => void;
   };
   [ModalType.WITHDRAW_GAS]: {
     setFieldValue: (field: string, value: any) => void;
@@ -367,7 +367,7 @@ const getModalData = (args: {
       modalContent = (
         <RefillGasTankModal
           close={popModal}
-          formikContext={current.props.formikContext}
+          setFieldValue={current.props.setFieldValue}
         />
       );
       break;

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -22,8 +22,8 @@ import ForkProposalTemplateModal from './ForkProposalTemplateModal';
 import { GaslessVoteFailedModal } from './GaslessVoting/GaslessVoteFailedModal';
 import { GaslessVoteLoadingModal } from './GaslessVoting/GaslessVoteLoadingModal';
 import { GaslessVoteSuccessModal } from './GaslessVoting/GaslessVoteSuccessModal';
-import { RefillGasData, RefillGasTankModal } from './GaslessVoting/RefillGasTankModal';
-import { WithdrawGasData, WithdrawGasTankModal } from './GaslessVoting/WithdrawGasTankModal';
+import { RefillGasTankModal } from './GaslessVoting/RefillGasTankModal';
+import { WithdrawGasTankModal } from './GaslessVoting/WithdrawGasTankModal';
 import { ModalBase, ModalBaseSize, ModalContentStyle } from './ModalBase';
 import PaymentCancelConfirmModal from './PaymentCancelConfirmModal';
 import { PaymentWithdrawModal } from './PaymentWithdrawModal';
@@ -118,12 +118,8 @@ export type ModalPropsTypes = {
     onSubmit: (airdropData: AirdropData) => void;
     submitButtonText: string;
   };
-  [ModalType.REFILL_GAS]: {
-    onSubmit: (refillGasData: RefillGasData) => void;
-  };
-  [ModalType.WITHDRAW_GAS]: {
-    onWithdraw: (withdrawGasData: WithdrawGasData) => void;
-  };
+  [ModalType.REFILL_GAS]: {};
+  [ModalType.WITHDRAW_GAS]: {};
   [ModalType.GASLESS_VOTE_LOADING]: {};
   [ModalType.GASLESS_VOTE_SUCCESS]: {};
   [ModalType.GASLESS_VOTE_FAILED]: {
@@ -364,26 +360,10 @@ const getModalData = (args: {
       );
       break;
     case ModalType.REFILL_GAS:
-      modalContent = (
-        <RefillGasTankModal
-          close={popModal}
-          refillGasData={(data: RefillGasData) => {
-            current.props.onSubmit(data);
-            popModal();
-          }}
-        />
-      );
+      modalContent = <RefillGasTankModal close={popModal} />;
       break;
     case ModalType.WITHDRAW_GAS:
-      modalContent = (
-        <WithdrawGasTankModal
-          close={popModal}
-          withdrawGasData={(data: WithdrawGasData) => {
-            current.props.onWithdraw(data);
-            popModal();
-          }}
-        />
-      );
+      modalContent = <WithdrawGasTankModal close={popModal} />;
       break;
     case ModalType.GASLESS_VOTE_SUCCESS:
       modalContent = <GaslessVoteSuccessModal close={popModal} />;

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Text } from '@chakra-ui/react';
 import { abis } from '@fractal-framework/fractal-contracts';
-import { Formik, Form, useFormikContext } from 'formik';
-import { useState } from 'react';
+import { Formik, Form, useFormikContext, FormikContextType } from 'formik';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -37,6 +37,7 @@ import { SafeGeneralSettingsPage } from '../../../pages/dao/settings/general/Saf
 import { useDAOStore } from '../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useProposalActionsStore } from '../../../store/actions/useProposalActionsStore';
+import { useSettingsFormStore } from '../../../store/settings/useSettingsFormStore';
 import {
   AzoriusGovernance,
   BigIntValuePair,
@@ -109,6 +110,16 @@ export type SafeSettingsFormikErrors = {
   general?: GeneralEditFormikErrors;
   paymasterGasTank?: PaymasterGasTankEditFormikErrors;
 };
+
+function FormStateSync({ formikContext }: { formikContext: FormikContextType<SafeSettingsEdits> }) {
+  const { setFormState } = useSettingsFormStore();
+
+  useEffect(() => {
+    setFormState(formikContext.values);
+  }, [formikContext.values, setFormState]);
+
+  return null;
+}
 
 export function SafeSettingsModal({
   closeModal,
@@ -1228,26 +1239,29 @@ export function SafeSettingsModal({
         submitAllSettingsEditsProposal(values);
       }}
     >
-      <Form>
-        <Flex
-          flexDirection="column"
-          height="90vh"
-          textColor="color-neutral-100"
-        >
+      {formikContext => (
+        <Form>
+          <FormStateSync formikContext={formikContext} />
           <Flex
-            flex="1"
-            height="100%"
-            pl="1"
+            flexDirection="column"
+            height="90vh"
+            textColor="color-neutral-100"
           >
-            <SettingsNavigation onSettingsNavigationClick={handleSettingsNavigationClick} />
-            <Divider vertical />
-            {settingsContent}
-          </Flex>
+            <Flex
+              flex="1"
+              height="100%"
+              pl="1"
+            >
+              <SettingsNavigation onSettingsNavigationClick={handleSettingsNavigationClick} />
+              <Divider vertical />
+              {settingsContent}
+            </Flex>
 
-          <Divider />
-          <ActionButtons />
-        </Flex>
-      </Form>
+            <Divider />
+            <ActionButtons />
+          </Flex>
+        </Form>
+      )}
     </Formik>
   );
 }

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -1177,7 +1177,7 @@ export function SafeSettingsModal({
         }
 
         if (values.paymasterGasTank) {
-          const { withdraw, deposit } = values.paymasterGasTank;
+          const { withdraw } = values.paymasterGasTank;
 
           if (withdraw) {
             if (withdraw.amount?.bigintValue !== undefined && depositInfo?.balance !== undefined) {
@@ -1211,22 +1211,7 @@ export function SafeSettingsModal({
             };
           }
 
-          if (deposit) {
-            if (!deposit.amount?.value || deposit.amount.bigintValue === 0n) {
-              errors.paymasterGasTank = {
-                ...errors.paymasterGasTank,
-                deposit: {
-                  ...errors.paymasterGasTank?.deposit,
-                  amount: t('amountRequired', { ns: 'common' }),
-                },
-              };
-            }
-          } else {
-            errors.paymasterGasTank = {
-              ...errors.paymasterGasTank,
-              deposit: undefined,
-            };
-          }
+          // Deposit validation handled in RefillGasTankModal, necessarily.
         } else {
           errors.paymasterGasTank = undefined;
         }

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -284,6 +284,7 @@ export function SafeSettingsModal({
             {t('withdrawGasAction', {
               amount: formattedWithdrawAmount,
               symbol: nativeCurrency.symbol,
+              ns: 'gaslessVoting',
             })}
           </Text>
         ),
@@ -1210,8 +1211,7 @@ export function SafeSettingsModal({
               withdraw: undefined,
             };
           }
-
-          // Deposit validation handled in RefillGasTankModal, necessarily.
+          // Deposit validation handled in RefillGasTankModal.
         } else {
           errors.paymasterGasTank = undefined;
         }

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -14,7 +14,6 @@ import {
   keccak256,
   parseAbiParameters,
 } from 'viem';
-import { EntryPoint07Abi } from '../../../assets/abi/EntryPoint07Abi';
 import {
   linearERC20VotingWithWhitelistSetupParams,
   linearERC721VotingWithWhitelistSetupParams,
@@ -29,7 +28,6 @@ import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useValidationAddress } from '../../../hooks/schemas/common/useValidationAddress';
 import { useNetworkEnsAddressAsync } from '../../../hooks/useNetworkEnsAddress';
 import useNetworkPublicClient from '../../../hooks/useNetworkPublicClient';
-import { useNetworkWalletClient } from '../../../hooks/useNetworkWalletClient';
 import { useCanUserCreateProposal } from '../../../hooks/utils/useCanUserSubmitProposal';
 import { useInstallVersionedVotingStrategy } from '../../../hooks/utils/useInstallVersionedVotingStrategy';
 import { generateContractByteCodeLinear } from '../../../models/helpers/utils';
@@ -235,7 +233,6 @@ export function SafeSettingsModal({
   const { getEnsAddress } = useNetworkEnsAddressAsync();
 
   const publicClient = useNetworkPublicClient();
-  const { data: walletClient } = useNetworkWalletClient();
 
   const gaslessVotingFeatureEnabled = useFeatureFlag('flag_gasless_voting');
 
@@ -297,19 +294,6 @@ export function SafeSettingsModal({
       }
 
       if (paymasterGasTank.deposit.isDirectDeposit) {
-        if (!walletClient) {
-          throw new Error('Wallet client not found');
-        }
-
-        const entryPoint = getContract({
-          address: accountAbstraction.entryPointv07,
-          abi: EntryPoint07Abi,
-          client: walletClient,
-        });
-
-        entryPoint.write.depositTo([paymasterAddress], {
-          value: paymasterGasTank.deposit.amount.bigintValue,
-        });
         return;
       }
 

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -1165,36 +1165,36 @@ export function SafeSettingsModal({
           const { withdraw, deposit } = values.paymasterGasTank;
 
           if (withdraw) {
-            if (!withdraw.amount?.value) {
-              errors.paymasterGasTank = {
-                ...errors.paymasterGasTank,
-                withdraw: {
-                  ...errors.paymasterGasTank?.withdraw,
-                  amount: t('amountRequired', { ns: 'common' }),
-                },
-              };
-
-              if (!withdraw.recipientAddress) {
+            if (withdraw.amount?.bigintValue !== undefined && depositInfo?.balance !== undefined) {
+              if (withdraw.amount.bigintValue > depositInfo.balance) {
+                console.log('overdraft');
                 errors.paymasterGasTank = {
                   ...errors.paymasterGasTank,
                   withdraw: {
                     ...errors.paymasterGasTank?.withdraw,
-                    recipientAddress: t('recipientAddressRequired'),
+                    amount: t('errorInsufficientBalance', { ns: 'common' }),
                   },
                 };
-              } else {
-                const validation = await validateAddress({ address: withdraw.recipientAddress });
-                if (!validation.validation.isValidAddress) {
-                  errors.paymasterGasTank = {
-                    ...errors.paymasterGasTank,
-                    withdraw: {
-                      ...errors.paymasterGasTank?.withdraw,
-                      recipientAddress: t('errorInvalidAddress', { ns: 'common' }),
-                    },
-                  };
-                }
               }
             }
+
+            if (withdraw.recipientAddress !== undefined) {
+              const validation = await validateAddress({ address: withdraw.recipientAddress });
+              if (!validation.validation.isValidAddress) {
+                errors.paymasterGasTank = {
+                  ...errors.paymasterGasTank,
+                  withdraw: {
+                    ...errors.paymasterGasTank?.withdraw,
+                    recipientAddress: t('errorInvalidAddress', { ns: 'common' }),
+                  },
+                };
+              }
+            }
+          } else {
+            errors.paymasterGasTank = {
+              ...errors.paymasterGasTank,
+              withdraw: undefined,
+            };
           }
 
           if (deposit) {
@@ -1207,7 +1207,14 @@ export function SafeSettingsModal({
                 },
               };
             }
+          } else {
+            errors.paymasterGasTank = {
+              ...errors.paymasterGasTank,
+              deposit: undefined,
+            };
           }
+        } else {
+          errors.paymasterGasTank = undefined;
         }
 
         if (Object.values(errors).every(e => e === undefined)) {

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -83,7 +83,7 @@ export type SafeSettingsEdits = {
   };
   paymasterGasTank?: {
     withdraw?: { recipientAddress?: Address; amount?: BigIntValuePair };
-    deposit?: { amount?: BigIntValuePair; isDirectDeposit: boolean };
+    deposit?: { amount?: BigIntValuePair; isDirectDeposit?: boolean };
   };
   permissions?: {
     proposerThreshold?: BigIntValuePair;

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -112,11 +112,15 @@ export type SafeSettingsFormikErrors = {
 };
 
 function FormStateSync({ formikContext }: { formikContext: FormikContextType<SafeSettingsEdits> }) {
-  const { setFormState } = useSettingsFormStore();
+  const { setFormState, setFormErrors } = useSettingsFormStore();
 
   useEffect(() => {
-    setFormState(formikContext.values);
+    setFormState({ ...formikContext.values });
   }, [formikContext.values, setFormState]);
+
+  useEffect(() => {
+    setFormErrors(formikContext.errors as unknown as SafeSettingsFormikErrors);
+  }, [formikContext.errors, setFormErrors]);
 
   return null;
 }
@@ -1178,12 +1182,11 @@ export function SafeSettingsModal({
           if (withdraw) {
             if (withdraw.amount?.bigintValue !== undefined && depositInfo?.balance !== undefined) {
               if (withdraw.amount.bigintValue > depositInfo.balance) {
-                console.log('overdraft');
                 errors.paymasterGasTank = {
                   ...errors.paymasterGasTank,
                   withdraw: {
                     ...errors.paymasterGasTank?.withdraw,
-                    amount: t('errorInsufficientBalance', { ns: 'common' }),
+                    amount: t('amountExceedsAvailableBalance', { ns: 'gaslessVoting' }),
                   },
                 };
               }

--- a/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
+++ b/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
@@ -89,6 +89,15 @@ export function SafeGeneralSettingsPage() {
     }
   }, [setFieldValue, formValues.general]);
 
+  useEffect(() => {
+    if (
+      formValues.paymasterGasTank?.withdraw === undefined &&
+      formValues.paymasterGasTank?.deposit === undefined
+    ) {
+      setFieldValue('paymasterGasTank', undefined);
+    }
+  }, [setFieldValue, formValues.paymasterGasTank]);
+
   const {
     chain: { id: chainId },
     contracts: { keyValuePairs, accountAbstraction, paymaster, zodiacModuleProxyFactory },

--- a/src/store/settings/useSettingsFormStore.ts
+++ b/src/store/settings/useSettingsFormStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { SafeSettingsEdits } from '../../components/ui/modals/SafeSettingsModal';
+
+interface SettingsFormStore {
+  formState: SafeSettingsEdits | null;
+  setFormState: (state: SafeSettingsEdits) => void;
+  updateFormState: (updates: Partial<SafeSettingsEdits>) => void;
+}
+
+export const useSettingsFormStore = create<SettingsFormStore>(set => ({
+  formState: null,
+  setFormState: state => set({ formState: state }),
+  updateFormState: updates =>
+    set(state => ({
+      formState: state.formState
+        ? { ...state.formState, ...updates }
+        : (updates as SafeSettingsEdits),
+    })),
+}));

--- a/src/store/settings/useSettingsFormStore.ts
+++ b/src/store/settings/useSettingsFormStore.ts
@@ -1,19 +1,19 @@
 import { create } from 'zustand';
-import { SafeSettingsEdits } from '../../components/ui/modals/SafeSettingsModal';
+import {
+  SafeSettingsEdits,
+  SafeSettingsFormikErrors,
+} from '../../components/ui/modals/SafeSettingsModal';
 
 interface SettingsFormStore {
-  formState: SafeSettingsEdits | null;
+  formState: SafeSettingsEdits | undefined;
+  formErrors: SafeSettingsFormikErrors | undefined;
   setFormState: (state: SafeSettingsEdits) => void;
-  updateFormState: (updates: Partial<SafeSettingsEdits>) => void;
+  setFormErrors: (errors: SafeSettingsFormikErrors) => void;
 }
 
 export const useSettingsFormStore = create<SettingsFormStore>(set => ({
-  formState: null,
+  formState: undefined,
+  formErrors: undefined,
   setFormState: state => set({ formState: state }),
-  updateFormState: updates =>
-    set(state => ({
-      formState: state.formState
-        ? { ...state.formState, ...updates }
-        : (updates as SafeSettingsEdits),
-    })),
+  setFormErrors: errors => set({ formErrors: errors }),
 }));

--- a/src/utils/dao/prepareRefillPaymasterActionData.ts
+++ b/src/utils/dao/prepareRefillPaymasterActionData.ts
@@ -2,7 +2,7 @@ import { Address } from 'viem';
 import { CreateProposalActionData, ProposalActionType } from '../../types';
 import { formatCoin } from '../numberFormats';
 
-export interface RefillPaymasterData {
+interface RefillPaymasterData {
   entryPointAddress: Address;
   paymasterAddress: Address;
   refillAmount: bigint;

--- a/src/utils/dao/prepareWithdrawPaymasterActionData.ts
+++ b/src/utils/dao/prepareWithdrawPaymasterActionData.ts
@@ -1,6 +1,10 @@
 import { Address } from 'viem';
-import { WithdrawGasData } from '../../components/ui/modals/GaslessVoting/WithdrawGasTankModal';
 import { CreateProposalActionData, ProposalActionType } from '../../types';
+
+interface WithdrawGasData {
+  withdrawAmount: bigint;
+  recipientAddress: Address;
+}
 
 export interface WithdrawPaymasterData {
   paymasterAddress: Address;

--- a/src/utils/dao/prepareWithdrawToDAOActionData.ts
+++ b/src/utils/dao/prepareWithdrawToDAOActionData.ts
@@ -3,7 +3,7 @@ import { SablierV2LockupLinearAbi } from '../../assets/abi/SablierV2LockupLinear
 import { convertStreamIdToBigInt } from '../../hooks/streams/useCreateSablierStream';
 import { CreateProposalActionData, ProposalActionType } from '../../types';
 
-export interface WithdrawStreamData {
+interface WithdrawStreamData {
   daoAddress: Address;
   roleHatSmartAccountAddress: Address;
   paymentContractAddress: Address;


### PR DESCRIPTION
<img width="1202" alt="Screenshot 2025-06-13 at 20 10 37" src="https://github.com/user-attachments/assets/5bb6940a-9431-4c5f-895a-70b61e65b8ae" />

<img width="1317" alt="Screenshot 2025-06-13 at 20 11 16" src="https://github.com/user-attachments/assets/740b1e69-33af-4ad6-ba5d-9fb0e1e436e7" />

### Key changes include:
#### Form State Management Rework:
The deposit/withdraw modals apparently exist outside the context of the settings modal context, so error and value update were not propagating onto the form. So:
- Introduced a new settings form store for better state handling
- Replaced Formik context with setFieldValue for improved state management
- Streamlined form state management and validation across modals

#### Modal Component Updates:
- Updated WithdrawGasTankModal and RefillGasTankModal to use the new form state management
- Improved validation and error handling for deposit/withdraw actions
- Added proper balance checks and error messages for insufficient funds

#### Direct Deposit Handling:
- Added direct deposit functionality that bypasses the settings modal, because that does not go to a proposal
- Added validation for paymaster address and amount

#### Misc
- Added proper edit detection and button visibility for gas operations

This PR will become part of a larger effort to improve settings' modal form value/error handling. Specifically I intend to move from Formik into the new `useSettingsFormStore` so as to not worry about hecking formikContext.
