### PR TITLE
`[ENG-1170]` | Fix `delegates` call

### DIFF
--- a/src/store/fetchers/governance.ts
+++ b/src/store/fetchers/governance.ts
@@ -308,7 +308,7 @@ export function useGovernanceFetcher() {
               {
                 ...tokenContract,
                 functionName: 'delegates',
-                args: [votesTokenAddress],
+                args: [user.address],
               },
             ];
 


### PR DESCRIPTION
Was using token address instead of user address 🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️🤦🏾‍♂️