### PR TITLE
[ENG-1277] Fix automation workflow for `pull` trigger

### DIFF
--- a/.github/workflows/ui-automation.yaml
+++ b/.github/workflows/ui-automation.yaml
@@ -46,9 +46,13 @@ jobs:
           commit: ${{ github.sha }}
           state: merged
 
+      - name: Prepend artifact link to summary
+        run: |
+          echo "[⬇️ Download Selenium Test Artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n" | cat - decent-ui-automation/test-results/test-results-summary.md > decent-ui-automation/test-results/test-results-summary.with-link.md
+
       - name: Comment results on PR
         if: steps.find_pr.outputs.pull_request_number != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.find_pr.outputs.pull_request_number }}
-          path: decent-ui-automation/test-results/test-results-summary.md
+          path: decent-ui-automation/test-results/test-results-summary.with-link.md

--- a/.github/workflows/ui-automation.yaml
+++ b/.github/workflows/ui-automation.yaml
@@ -39,8 +39,16 @@ jobs:
           name: selenium-test-results
           path: decent-ui-automation/test-results/
 
+      - name: Find merged pull request
+        id: find_pr
+        uses: peter-evans/find-pull-request@v5
+        with:
+          commit: ${{ github.sha }}
+          state: merged
+
       - name: Comment results on PR
-        if: github.event_name == 'pull_request'
+        if: steps.find_pr.outputs.pull_request_number != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          number: ${{ steps.find_pr.outputs.pull_request_number }}
           path: decent-ui-automation/test-results/test-results-summary.md


### PR DESCRIPTION
This makes two changes:

1. Updates the workflow to make it so that the test results comment can be posted on a PR post merge. The original workflow was written expecting the trigger to be `on: pull-request`, making the target of the comment implicit. The update here attempts to locate the PR associated with a push and adds the comment to it, retroactively.
2. Updates the workflow to add a link to the build artifacts to the test results comment. I think this might be more necessary with the workflow not being used as a check on the PR. If I'm wrong about this, the change will still make it easier and is worthwhile if it works.