### PR TITLE
`[ENG-1270]` expose closeAllModals and add closeBaseModal optional prop in ModalContext

### DIFF
--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -155,12 +155,14 @@ export interface IModalContext {
   openModals: ModalTypeWithProps[];
   pushModal: (modal: ModalTypeWithProps) => void;
   popModal: () => void;
+  closeAllModals: () => void;
 }
 
 export const ModalContext = createContext<IModalContext>({
   openModals: [],
   pushModal: () => {},
   popModal: () => {},
+  closeAllModals: () => {},
 });
 
 interface ModalData {
@@ -577,9 +579,11 @@ function ModalDisplay({
 export function ModalProvider({
   children,
   baseZIndex = 1400,
+  closeBaseModal,
 }: {
   children: ReactNode;
   baseZIndex?: number;
+  closeBaseModal?: () => void;
 }) {
   const [openModals, setOpenModals] = useState<ModalTypeWithProps[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -595,8 +599,11 @@ export function ModalProvider({
 
   const closeAllModals = useCallback(() => {
     setOpenModals([]);
+    if (closeBaseModal) {
+      closeBaseModal();
+    }
     onClose();
-  }, [onClose]);
+  }, [onClose, closeBaseModal]);
 
   useEffect(() => {
     if (openModals.length > 0) {
@@ -626,7 +633,7 @@ export function ModalProvider({
   });
 
   return (
-    <ModalContext.Provider value={{ openModals, pushModal, popModal }}>
+    <ModalContext.Provider value={{ openModals, pushModal, popModal, closeAllModals }}>
       {children}
       <Portal>{modalDisplays}</Portal>
     </ModalContext.Provider>

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -1417,7 +1417,10 @@ export function SafeSettingsModal({
       }}
     >
       <Form>
-        <ModalProvider baseZIndex={2000}>
+        <ModalProvider
+          baseZIndex={2000}
+          closeBaseModal={closeModal}
+        >
           <Flex
             flexDirection="column"
             height="90vh"

--- a/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
+++ b/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
@@ -160,7 +160,7 @@ export function SafeTokenSettingsPage() {
       : undefined,
   );
 
-  const { popModal } = useContext(ModalContext);
+  const { closeAllModals } = useContext(ModalContext);
   const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
 
   const isTransferableInValues = values.token?.transferable;
@@ -282,7 +282,7 @@ export function SafeTokenSettingsPage() {
               <Button
                 onClick={() => {
                   if (!safe) return;
-                  popModal();
+                  closeAllModals();
                   navigate(DAO_ROUTES.deployToken.relative(addressPrefix, safe.address));
                 }}
               >


### PR DESCRIPTION
### Summary

* **ModalContext** now exposes a `closeAllModals` function. This is useful for pages embedded within a modal that don’t have direct access to the `closeAll` prop—they can now access it via context.
* Added an optional `closeBaseModal` prop to `ModalProvider`. This allows customizing how to close the base modal, even if it exists outside the current `ModalContext`.
* Updated `SafeTokenSettingsPage.tsx` to use `closeAllModals` when navigating to the deploy token page. This ensures all modals are properly closed during navigation.