### PR TITLE
`[ENG-1154]` get staking address from create2 instead of fixed test value

### DIFF
--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -90,6 +90,7 @@ export const baseConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddressFromContractDeploymentInfo(a.VotesERC20),
     votesErc20LockableMasterCopy: addresses.deployables.VotesERC20V1,
+    votesERC20StakedV1MasterCopy: addresses.deployables.VotesERC20StakedV1,
 
     claimErc20MasterCopy: getAddressFromContractDeploymentInfo(a.ERC20Claim),
 

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -93,6 +93,7 @@ export const mainnetConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddressFromContractDeploymentInfo(a.VotesERC20),
     votesErc20LockableMasterCopy: addresses.deployables.VotesERC20V1,
+    votesERC20StakedV1MasterCopy: addresses.deployables.VotesERC20StakedV1,
 
     claimErc20MasterCopy: getAddressFromContractDeploymentInfo(a.ERC20Claim),
 

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -90,6 +90,7 @@ export const optimismConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddressFromContractDeploymentInfo(a.VotesERC20),
     votesErc20LockableMasterCopy: addresses.deployables.VotesERC20V1,
+    votesERC20StakedV1MasterCopy: addresses.deployables.VotesERC20StakedV1,
 
     claimErc20MasterCopy: getAddressFromContractDeploymentInfo(a.ERC20Claim),
 

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -90,6 +90,7 @@ export const polygonConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddressFromContractDeploymentInfo(a.VotesERC20),
     votesErc20LockableMasterCopy: addresses.deployables.VotesERC20V1,
+    votesERC20StakedV1MasterCopy: addresses.deployables.VotesERC20StakedV1,
 
     claimErc20MasterCopy: getAddressFromContractDeploymentInfo(a.ERC20Claim),
 

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -93,6 +93,7 @@ export const sepoliaConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddressFromContractDeploymentInfo(a.VotesERC20),
     votesErc20LockableMasterCopy: addresses.deployables.VotesERC20V1,
+    votesERC20StakedV1MasterCopy: addresses.deployables.VotesERC20StakedV1,
 
     claimErc20MasterCopy: getAddressFromContractDeploymentInfo(a.ERC20Claim),
 

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -40,6 +40,7 @@ type ContractsBase = {
 
   votesErc20MasterCopy: Address;
   votesErc20LockableMasterCopy?: Address;
+  votesERC20StakedV1MasterCopy?: Address;
 
   claimErc20MasterCopy: Address;
 

--- a/src/utils/stakingContractUtils.ts
+++ b/src/utils/stakingContractUtils.ts
@@ -1,14 +1,13 @@
+import { abis } from '@decentdao/decent-contracts';
 import {
   Address,
-  encodeAbiParameters,
   encodeFunctionData,
   encodePacked,
   getCreate2Address,
   keccak256,
-  parseAbiParameters,
   stringToHex,
 } from 'viem';
-import { generateContractByteCodeLinear } from '../models/helpers/utils';
+import { generateContractByteCodeLinear, generateSalt } from '../models/helpers/utils';
 
 export const getStakingContractSaltNonce = (safeAddress: Address, chainId: number) => {
   const salt = `${safeAddress}-${chainId}`;
@@ -19,41 +18,35 @@ export const getStakingContractSaltNonce = (safeAddress: Address, chainId: numbe
 
 export const getStakingContractAddress = (args: {
   safeAddress: Address;
+  stakedTokenAddress: Address;
   zodiacModuleProxyFactory: Address;
   stakingContractMastercopy: Address;
   chainId: number;
 }) => {
-  // @todo: Implement (https://linear.app/decent-labs/issue/ENG-1154/implement-getstakingcontractaddress)
-  return '0x1234567890123456789012345678901234567890';
-  const { safeAddress, zodiacModuleProxyFactory, stakingContractMastercopy, chainId } = args;
+  const {
+    safeAddress,
+    stakedTokenAddress,
+    zodiacModuleProxyFactory,
+    stakingContractMastercopy,
+    chainId,
+  } = args;
 
-  const encodedStakingContractInitializationParams = encodeAbiParameters(
-    parseAbiParameters('address'),
-    [stakingContractMastercopy],
-  );
-
-  const encodedStakingContractInitializationData = encodeFunctionData({
-    abi: 'legacy.abis.DecentStakingContractV1' as any, // @todo: Use abi from contracts
+  const encodedInitializationData = encodeFunctionData({
+    abi: abis.deployables.VotesERC20StakedV1,
     functionName: 'initialize',
-    args: [encodedStakingContractInitializationParams],
+    args: [safeAddress, stakedTokenAddress],
   });
 
-  const salt = keccak256(
-    encodePacked(
-      ['bytes32', 'uint256'],
-      [
-        keccak256(encodePacked(['bytes'], [encodedStakingContractInitializationData])),
-        getStakingContractSaltNonce(safeAddress, chainId),
-      ],
-    ),
+  const byteCodeLinear = generateContractByteCodeLinear(stakingContractMastercopy);
+  const salt = generateSalt(
+    encodedInitializationData,
+    getStakingContractSaltNonce(safeAddress, chainId),
   );
 
   const predictedStakingContractAddress = getCreate2Address({
     from: zodiacModuleProxyFactory,
     salt: salt,
-    bytecodeHash: keccak256(
-      encodePacked(['bytes'], [generateContractByteCodeLinear(stakingContractMastercopy)]),
-    ),
+    bytecodeHash: keccak256(encodePacked(['bytes'], [byteCodeLinear])),
   });
 
   return predictedStakingContractAddress;


### PR DESCRIPTION
Depends on #3194 

### Summary

- Update `NetworkConfig` to add `votesERC20StakedV1MasterCopy` address which is specified in contracts package.
- Update `getStakingContractAddress` to calculate instead return fixed test value