### PR TITLE
`[ENG-1339]` Display token information in Token tab for existing token contract

### DIFF
--- a/src/hooks/DAO/useLockedToken.ts
+++ b/src/hooks/DAO/useLockedToken.ts
@@ -10,6 +10,7 @@ interface LockedTokenState {
   whitelisted: boolean;
   canTransfer: boolean;
   needWhitelist: boolean;
+  isImportedToken: boolean;
 }
 
 const DEFAULT_STATE = {
@@ -17,6 +18,7 @@ const DEFAULT_STATE = {
   whitelisted: false,
   canTransfer: true,
   needWhitelist: false,
+  isImportedToken: true,
 };
 
 export default function useLockedToken(
@@ -46,6 +48,7 @@ export default function useLockedToken(
           whitelisted,
           canTransfer: !locked || whitelisted || canGrantRole,
           needWhitelist: locked && !whitelisted,
+          isImportedToken: false,
         };
       } catch (e) {
         console.warn('Failed to read locked token state', e);

--- a/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
+++ b/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
@@ -302,7 +302,7 @@ export function SafeTokenSettingsPage() {
             </Flex>
           )}
 
-          {erc20Token && (
+          {erc20Token && !tokenState.isImportedToken && (
             <>
               <Flex
                 gap={4}
@@ -441,6 +441,7 @@ export function SafeTokenSettingsPage() {
                         setFieldValue('token.maximumTotalSupply', undefined);
                       }
                     }}
+                    isDisabled={tokenState.isImportedToken}
                     decimalPlaces={erc20Token.decimals}
                     onKeyDown={restrictChars}
                   />

--- a/src/store/fetchers/governance.ts
+++ b/src/store/fetchers/governance.ts
@@ -1012,51 +1012,53 @@ export function useGovernanceFetcher() {
         });
 
         // Execute multicall
-        const [name, symbol, decimals, totalSupply, maxTotalSupply] = await publicClient.multicall({
-          contracts: [
-            {
-              ...tokenContract,
-              functionName: 'name',
-            },
-            {
-              ...tokenContract,
-              functionName: 'symbol',
-            },
-            {
-              ...tokenContract,
-              functionName: 'decimals',
-            },
-            {
-              ...tokenContract,
-              functionName: 'totalSupply',
-            },
-            {
-              ...tokenContract,
-              functionName: 'maxTotalSupply',
-            },
-          ],
-          allowFailure: false,
-        });
+        const [nameData, symbolData, decimalsData, totalSupplyData, maxTotalSupplyData] =
+          await publicClient.multicall({
+            contracts: [
+              {
+                ...tokenContract,
+                functionName: 'name',
+              },
+              {
+                ...tokenContract,
+                functionName: 'symbol',
+              },
+              {
+                ...tokenContract,
+                functionName: 'decimals',
+              },
+              {
+                ...tokenContract,
+                functionName: 'totalSupply',
+              },
+              {
+                ...tokenContract,
+                functionName: 'maxTotalSupply',
+              },
+            ],
+            allowFailure: true,
+          });
 
         const tokenData: ERC20LockedTokenData = {
-          name: name ? name.toString() : '',
-          symbol: symbol ? symbol.toString() : '',
-          decimals: decimals ? Number(decimals) : 18,
+          name: nameData.result || '',
+          symbol: symbolData.result || '',
+          decimals: decimalsData.result !== undefined ? decimalsData.result : 18,
           address: tokenContract.address,
-          totalSupply: totalSupply ? BigInt(totalSupply) : 0n,
-          maxTotalSupply: maxTotalSupply ? BigInt(maxTotalSupply) : 0n,
+          totalSupply: totalSupplyData.result !== undefined ? totalSupplyData.result : 0n,
+          maxTotalSupply: maxTotalSupplyData.result !== undefined ? maxTotalSupplyData.result : 0n,
           whitelistedAddresses,
         };
 
         return tokenData;
       } catch (e) {
         logError({
-          message: 'Error getting erc20Address data',
+          message: 'Error getting erc20Token data',
           network: publicClient.chain!.id,
           args: {
             transactionHash: erc20AddressEvent.transactionHash,
             logIndex: erc20AddressEvent.logIndex,
           },
+          error: e,
         });
 
         return;


### PR DESCRIPTION
### Summary

* Added `isImportedToken` field to the `useLockedToken` hook to determine whether a token was deployed using the locked token contract.
* Hid token management UI for imported ERC20 tokens in the Token Settings tab.
* Updated `fetchMultisigERC20Token` to tolerate failures in multicall, allowing support for imported tokens that do not implement `maxTotalSupply` without reverting.

### Screenshot
<img width="1184" height="927" alt="image" src="https://github.com/user-attachments/assets/e335f299-7ca5-4c2f-9dc9-bd8a147fd2c4" />

