### PR TITLE
Added some guards against checking out the wrong automation repo and logging to match

### DIFF
--- a/.github/workflows/ui-automation.yaml
+++ b/.github/workflows/ui-automation.yaml
@@ -57,6 +57,12 @@ jobs:
         with:
           repository: decentdao/decent-ui-automation
           path: ui-automation
+          fetch-depth: 0
+          clean: true
+
+      - name: Print commit hash
+        working-directory: ui-automation
+        run: git rev-parse HEAD
 
       - name: Install dependencies in automation repo
         working-directory: ui-automation


### PR DESCRIPTION
There's evidence that the tests are running against old code. Flakiness fixes for the governance tab test have consistently done nothing when the tests are run in CI. Just recently I made a change that should have been apparent in test results screenshots which was not which has me even more suspicious.

This change at worst won't fix anything.