### PR TITLE
`[ENG-1346]` Staking holdings for reward tokens & UI updates

### DIFF
--- a/functions/balances/index.ts
+++ b/functions/balances/index.ts
@@ -15,7 +15,8 @@ const endpoints = {
   tokens: {
     moralisPath: (address: string) => `/wallets/${address}/tokens`,
     transform: transformTokenResponse,
-    postProcess: (data: TokenBalance[]) => data.filter(token => token.balance !== '0'),
+    postProcess: (data: TokenBalance[]) =>
+      data.filter(token => token.nativeToken || token.balance !== '0'),
     fetch: async ({ chain, address }: { chain: string; address: string }, c: { env: Env }) => {
       const result = await fetchMoralis<TokenResponse>({
         endpoint: endpoints.tokens.moralisPath(address),

--- a/public/locales/en/staking.json
+++ b/public/locales/en/staking.json
@@ -4,8 +4,8 @@
   "deployStaking": "Deploy Staking Contract",
   "stakingPeriod": "Staking Period",
   "undistributedTokensTitle": "Undistributed Tokens",
-  "undistributedTokensHelper": "The following tokens are held by the contract but are not being distributed as rewards. Add them to the list of Reward Tokens below.",
+  "undistributedTokensHelper": "Any tokens displayed here were received as revenue but are not being distributed as rewards. To distribute these types of tokens, add them to the list of Reward Tokens below.",
   "rewardTokensTitle": "Reward Tokens",
-  "rewardTokensHelper": "Specify which tokens from incoming revenue will distributed as rewards. You can't delete reward tokens.",
+  "rewardTokensHelper": "Specify which tokens from incoming revenue will be distributed as rewards. Once added, tokens cannot be removed from this list!",
   "addRewardToken": "Add Token"
 }

--- a/src/pages/dao/settings/staking/SafeStakingSettingsPage.tsx
+++ b/src/pages/dao/settings/staking/SafeStakingSettingsPage.tsx
@@ -53,7 +53,8 @@ function StakingForm() {
         label={t('stakingPeriod')}
         isRequired
         gridContainerProps={{
-          my: 2,
+          mt: 2,
+          mb: 4,
           templateColumns: '1fr',
           width: { base: '100%', md: '50%' },
         }}
@@ -80,34 +81,36 @@ function StakingForm() {
         />
       </LabelComponent>
 
-      <LabelComponent
-        label={t('undistributedTokensTitle')}
-        isRequired={false}
-        gridContainerProps={{
-          templateColumns: '1fr',
-          width: { base: '100%' },
-        }}
-        helper={t('undistributedTokensHelper')}
-      >
-        <UnorderedList>
-          {undistributedTokens.map(asset => (
-            <ListItem key={asset.tokenAddress}>
-              <DisplayAddress
-                address={asset.tokenAddress}
-                truncate={false}
-              >
-                <Text>{asset.symbol}</Text>
-              </DisplayAddress>
-            </ListItem>
-          ))}
-        </UnorderedList>
-      </LabelComponent>
+      {undistributedTokens.length > 0 && (
+        <LabelComponent
+          label={t('undistributedTokensTitle')}
+          isRequired={false}
+          gridContainerProps={{
+            my: 2,
+            templateColumns: '1fr',
+            width: { base: '100%' },
+          }}
+          helper={t('undistributedTokensHelper')}
+        >
+          <UnorderedList>
+            {undistributedTokens.map(asset => (
+              <ListItem key={asset.tokenAddress}>
+                <DisplayAddress
+                  address={asset.tokenAddress}
+                  truncate={false}
+                >
+                  <Text>{asset.symbol}</Text>
+                </DisplayAddress>
+              </ListItem>
+            ))}
+          </UnorderedList>
+        </LabelComponent>
+      )}
 
       <LabelComponent
         label={t('rewardTokensTitle')}
         isRequired={false}
         gridContainerProps={{
-          mt: 6,
           templateColumns: '1fr',
           width: { base: '100%' },
         }}


### PR DESCRIPTION
### Summary

- [ ] Use staking contract holdings and fixed USDC address in reward token selector
- [X] Update section spacing and copy.
- [ ] Use staking contract holdings in undistributedTokens
- [X] Refactor AssetSelector to use `assetsFungible` for native token too, removed extra call with `useBalance`.
- [X] Update Balance API to always return native token even it has zero balance. (we can always filter response later if needed).