### PR TITLE
`[ENG-1347]` Add test IDs to the settings modal tabs

### DIFF
--- a/src/components/SafeSettings/SettingsNavigation.tsx
+++ b/src/components/SafeSettings/SettingsNavigation.tsx
@@ -127,6 +127,7 @@ function SettingsNavigationItem({
   item = 'general',
   onClick,
   hasEdits = false,
+  testId,
 }: PropsWithChildren<{
   title: string;
   leftIcon: ReactNode;
@@ -135,6 +136,7 @@ function SettingsNavigationItem({
   currentItem: (typeof settingsNavigationItems)[number];
   onClick?: () => void;
   hasEdits?: boolean;
+  testId?: string;
 }>) {
   return (
     <Box
@@ -145,6 +147,7 @@ function SettingsNavigationItem({
       bg={currentItem === item ? 'white-alpha-04' : 'transparent'}
       p={{ base: 0, md: '0.5rem' }}
       cursor="pointer"
+      data-testid={testId}
     >
       <Flex
         alignItems="center"
@@ -258,6 +261,7 @@ export function SettingsNavigation({
             leftIcon={<GearFine fontSize="1.5rem" />}
             item="general"
             currentItem={currentItem}
+            testId="settings-nav-general"
             onClick={() => {
               onSettingsNavigationClick(<SafeGeneralSettingsPage />);
               setCurrentItem('general');
@@ -269,6 +273,7 @@ export function SettingsNavigation({
             leftIcon={<Bank fontSize="1.5rem" />}
             item="governance"
             currentItem={currentItem}
+            testId="settings-nav-governance"
             onClick={() => {
               onSettingsNavigationClick(<SafeGovernanceSettingsPage />);
               setCurrentItem('governance');
@@ -284,6 +289,7 @@ export function SettingsNavigation({
             leftIcon={<Stack fontSize="1.5rem" />}
             item="modulesAndGuard"
             currentItem={currentItem}
+            testId="settings-nav-modules"
             onClick={() => {
               onSettingsNavigationClick(<SafeModulesSettingsPage />);
               setCurrentItem('modulesAndGuard');
@@ -298,6 +304,7 @@ export function SettingsNavigation({
               item="permissions"
               currentItem={currentItem}
               showDivider={false}
+              testId="settings-nav-permissions"
               onClick={() => {
                 onSettingsNavigationClick(<SafePermissionsSettingsContent />);
                 setCurrentItem('permissions');
@@ -313,6 +320,7 @@ export function SettingsNavigation({
               leftIcon={<RocketLaunch fontSize="1.5rem" />}
               item="token"
               currentItem={currentItem}
+              testId="settings-nav-token"
               onClick={() => {
                 onSettingsNavigationClick(<SafeTokenSettingsPage />);
                 setCurrentItem('token');
@@ -327,6 +335,7 @@ export function SettingsNavigation({
               item="revenueSharing"
               currentItem={currentItem}
               showDivider={false}
+              testId="settings-nav-revenue-sharing"
               onClick={() => {
                 onSettingsNavigationClick(<SafeRevenueSharingSettingsPage />);
                 setCurrentItem('revenueSharing');
@@ -340,6 +349,7 @@ export function SettingsNavigation({
               item="staking"
               currentItem={currentItem}
               showDivider={false}
+              testId="settings-nav-staking"
               onClick={() => {
                 onSettingsNavigationClick(<SafeStakingSettingsPage />);
                 setCurrentItem('staking');


### PR DESCRIPTION
This is in essence what this change, and future changes of this nature, will look like:

<img width="1120" height="995" alt="image" src="https://github.com/user-attachments/assets/774e64fb-4fa0-438d-82f6-e1d1e37880af" />

Note that the divs where the ID is now present on had nothing else stable to refer to. For automated browser testing, you ideally want an ID type parameter to refer to, since it is unlikely to change and is unique to the element it's tied to.

If you're reduced to locating the text, such as the word "General" from the above, you risk flakiness or tests that require frequent maintenance. An example from recent history is from this modal, where the word "Governance" appears underneath the modal, at the top of the homepage, which means there's a race condition where that element may be selected instead of the correct one.