### PR TITLE
`[ENG-1348]` Use DurationUnitStepper for governance settings when creating new DAO

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -11,43 +11,46 @@ import {
 import { WarningCircle } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useFeatureFlag from '../../../helpers/environmentFeatureFlags';
 import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useDAOStore } from '../../../providers/App/AppProvider';
-import { FractalModuleType, ICreationStepProps, VotingStrategyType } from '../../../types';
-import { DEV_VOTING_PERIOD_MINUTES } from '../../../utils/dev/devModeConstants';
+import {
+  BigIntValuePair,
+  FractalModuleType,
+  ICreationStepProps,
+  VotingStrategyType,
+} from '../../../types';
 import { BigIntInput } from '../../ui/forms/BigIntInput';
 import { CustomNonceInput } from '../../ui/forms/CustomNonceInput';
+import DurationUnitStepperInput from '../../ui/forms/DurationUnitStepperInput';
 import { LabelComponent } from '../../ui/forms/InputComponent';
-import { NumberStepperInput } from '../../ui/forms/NumberStepperInput';
 import { StepButtons } from '../StepButtons';
 import { StepWrapper } from '../StepWrapper';
 import useStepRedirect from '../hooks/useStepRedirect';
 import { DAOCreateMode } from './EstablishEssentials';
 
-function DayStepperInput({
-  inputValue,
-  onInputChange,
-}: {
-  inputValue: number;
-  onInputChange: (val: number) => void;
-}) {
-  const { t } = useTranslation('common');
-
+function renderUnitInputWith(
+  formName: string,
+  formValue: BigIntValuePair,
+  setFieldValue: (name: string, value: any) => void,
+) {
   return (
-    <InputGroup>
-      <Flex
-        flexDirection="column"
-        gap="0.5rem"
-        w="250px"
-      >
-        <NumberStepperInput
-          rightElement={<Text color="color-neutral-700">{t('days', { ns: 'common' })}</Text>}
-          value={inputValue}
-          onChange={val => onInputChange(Number(val))}
-        />
-      </Flex>
-    </InputGroup>
+    <Flex
+      flexDirection="column"
+      gap="0.5rem"
+      w="300px"
+    >
+      <DurationUnitStepperInput
+        secondsValue={Number(formValue?.bigintValue ?? 0n) * 60}
+        onSecondsValueChange={sec => {
+          const min = sec ? sec / 60 : 0;
+          const newMinutesPair: BigIntValuePair = {
+            bigintValue: BigInt(min),
+            value: min.toString(),
+          };
+          setFieldValue(formName, newMinutesPair);
+        }}
+      />
+    </Flex>
   );
 }
 
@@ -82,32 +85,6 @@ export function AzoriusGovernance(props: ICreationStepProps) {
   }, [setFieldValue, safe, showCustomNonce, mode]);
 
   useStepRedirect({ values });
-
-  // Use local flag only for flag_dev
-  const devFeatureEnabled = useFeatureFlag('flag_dev');
-  const devModeVotingPeriodDays = DEV_VOTING_PERIOD_MINUTES / 24 / 60;
-  const defaultVotingPeriodDays = devFeatureEnabled ? devModeVotingPeriodDays : 7;
-
-  const [votingPeriodDays, setVotingPeriodDays] = useState(defaultVotingPeriodDays);
-  const [timelockPeriodDays, setTimelockPeriodDays] = useState(1);
-  const [executionPeriodDays, setExecutionPeriodDays] = useState(2);
-
-  useEffect(() => {
-    // convert days to minutes
-    const minutes = votingPeriodDays * 24 * 60;
-    setFieldValue('azorius.votingPeriod', { bigintValue: minutes, value: minutes.toString() });
-  }, [setFieldValue, votingPeriodDays]);
-
-  // same for timelock and execution period
-  useEffect(() => {
-    const minutes = timelockPeriodDays * 24 * 60;
-    setFieldValue('azorius.timelock', { bigintValue: minutes, value: minutes.toString() });
-  }, [setFieldValue, timelockPeriodDays]);
-
-  useEffect(() => {
-    const minutes = executionPeriodDays * 24 * 60;
-    setFieldValue('azorius.executionPeriod', { bigintValue: minutes, value: minutes.toString() });
-  }, [setFieldValue, executionPeriodDays]);
 
   return (
     <>
@@ -162,10 +139,11 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             helper={t('helperVotingPeriod')}
             isRequired
           >
-            <DayStepperInput
-              inputValue={votingPeriodDays}
-              onInputChange={setVotingPeriodDays}
-            />
+            {renderUnitInputWith(
+              'azorius.votingPeriod',
+              values.azorius.votingPeriod,
+              setFieldValue,
+            )}
           </LabelComponent>
 
           {/* TIMELOCK PERIOD */}
@@ -174,10 +152,7 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             helper={t('helperTimelockPeriod')}
             isRequired
           >
-            <DayStepperInput
-              inputValue={timelockPeriodDays}
-              onInputChange={setTimelockPeriodDays}
-            />
+            {renderUnitInputWith('azorius.timelock', values.azorius.timelock, setFieldValue)}
           </LabelComponent>
 
           {/* EXECUTION PERIOD */}
@@ -186,10 +161,11 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             helper={t('helperExecutionPeriod')}
             isRequired
           >
-            <DayStepperInput
-              inputValue={executionPeriodDays}
-              onInputChange={setExecutionPeriodDays}
-            />
+            {renderUnitInputWith(
+              'azorius.executionPeriod',
+              values.azorius.executionPeriod,
+              setFieldValue,
+            )}
           </LabelComponent>
 
           <Alert

--- a/src/components/DaoCreator/index.tsx
+++ b/src/components/DaoCreator/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@chakra-ui/react';
 import { Formik } from 'formik';
 
+import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { useDAOCreateSchema } from '../../hooks/schemas/DAOCreate/useDAOCreateSchema';
 import {
   AzoriusERC20DAO,
@@ -11,6 +12,7 @@ import {
   SafeMultisigDAO,
   SubDAO,
 } from '../../types';
+import { DEV_VOTING_PERIOD_MINUTES } from '../../utils/dev/devModeConstants';
 import StepController from './StepController';
 import { initialState } from './constants';
 import { DAOCreateMode } from './formComponents/EstablishEssentials';
@@ -37,6 +39,16 @@ function DaoCreator({
 
   const { prepareMultisigFormData, prepareAzoriusERC20FormData, prepareAzoriusERC721FormData } =
     usePrepareFormData();
+
+  const devFeatureEnabled = useFeatureFlag('flag_dev');
+  const modifiedInitialState = initialState;
+  if (devFeatureEnabled) {
+    const devModeVotingPeriodMins = BigInt(DEV_VOTING_PERIOD_MINUTES);
+    modifiedInitialState.azorius.votingPeriod = {
+      bigintValue: devModeVotingPeriodMins,
+      value: devModeVotingPeriodMins.toString(),
+    };
+  }
 
   return (
     <Box>

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -12,6 +12,7 @@ import {
 import { Plus, Minus } from '@phosphor-icons/react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { SEXY_BOX_SHADOW_T_T } from '../../../constants/common';
 import {
   SECONDS_IN_DAY,
   SECONDS_IN_HOUR,
@@ -80,7 +81,8 @@ export default function DurationUnitStepperInput({
   const stepperButton = (direction: 'inc' | 'dec') => (
     <Button
       variant="secondary"
-      borderColor="color-neutral-900"
+      border="none"
+      boxShadow={SEXY_BOX_SHADOW_T_T}
       p="0.5rem"
       size="md"
     >

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -24,6 +24,22 @@ interface DurationUnits {
   label: string;
 }
 
+function findBestDefaultUnit(
+  units: DurationUnits[],
+  secondsValue: number | undefined,
+): DurationUnits {
+  const sortedUnits = units.sort((a, b) => a.unit - b.unit);
+  if (secondsValue !== undefined) {
+    // Find the largest unit that divides the value evenly
+    const biggestUnit = sortedUnits.findLast(u => secondsValue % u.unit === 0);
+    if (biggestUnit) {
+      return biggestUnit;
+    }
+  }
+  // otherwise, return the smallest unit
+  return sortedUnits[0];
+}
+
 export default function DurationUnitStepperInput({
   secondsValue,
   onSecondsValueChange,
@@ -59,7 +75,7 @@ export default function DurationUnitStepperInput({
       label: t('years', { ns: 'common' }),
     },
   ];
-  const [selectedUnit, setSelectedUnit] = useState(units[2]);
+  const [selectedUnit, setSelectedUnit] = useState(findBestDefaultUnit(units, secondsValue));
 
   const stepperButton = (direction: 'inc' | 'dec') => (
     <Button


### PR DESCRIPTION
### Summary

* Updated `DurationUnitStepperInput` styling and logic to choose the largest unit that evenly divides the input value.
* Replaced `DayInput` with `UnitInput` on the create page to match the settings page, which already supports units beyond just "Days".
* Refactored to use form state variables directly instead of separate local state and effects — this improves efficiency and reduces potential bugs.
* Consolidated form defaults by updating `initialValues` directly, instead of setting them in multiple places.

### Screenshot

<img width="1252" height="798" alt="image" src="https://github.com/user-attachments/assets/6b3aedd5-403f-436c-8296-fe344362dfd4" />
