### PR TITLE
`[ENG-1343]` Add the option to set proposal permission value as part of token governance deployment

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -28,6 +28,7 @@
   "minutes": "Minutes",
   "minutesShort": "min",
   "quorum": "Quorum",
+  "proposalPermission": "Proposal Permission",
   "deploy": "Deploy",
   "loading": "Loading...",
   "goHome": "Go Home",

--- a/public/locales/en/daoCreate.json
+++ b/public/locales/en/daoCreate.json
@@ -32,6 +32,7 @@
   "helperVotingPeriod": "The length of time where voting is enabled after a proposal is created.",
   "helperQuorumERC20": "The percentage of total possible token votes required to vote on a proposal to make the result valid.",
   "helperQuorumERC721": "The minimum weight of total available token voting weight required to vote on a proposal to make the result valid.",
+  "helperProposalPermission": "The minimum number of tokens a member must hold in order to create proposals.",
   "governanceDescription": "These values can be modified later.",
   "titleGuardConfig": "Configure Administration",
   "titleFreezeParams": "Freeze Parameters",

--- a/src/components/DaoCreator/constants.ts
+++ b/src/components/DaoCreator/constants.ts
@@ -39,6 +39,10 @@ export const initialState: CreatorFormState = {
     maxTotalSupply: {
       value: '',
     },
+    requiredProposerWeight: {
+      value: '1',
+      bigintValue: 1n,
+    },
   },
   erc721Token: {
     nfts: [
@@ -52,6 +56,10 @@ export const initialState: CreatorFormState = {
     quorumThreshold: {
       value: '10',
       bigintValue: 10n,
+    },
+    proposerThreshold: {
+      value: '1',
+      bigintValue: 1n,
     },
   },
   /**

--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -133,23 +133,21 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             </LabelComponent>
           )}
 
-          {/* QUORUM */}
+          {/* PROPOSAL PERMISSION */}
           {values.azorius.votingStrategyType === VotingStrategyType.LINEAR_ERC20 ? (
             <LabelComponent
               label={t('proposalPermission', { ns: 'common' })}
               helper={t('helperProposalPermission')}
               isRequired
             >
-              <InputGroup>
-                <BigIntInput
-                  value={values.azorius.quorumPercentage.bigintValue}
-                  onChange={valuePair => setFieldValue('azorius.quorumPercentage', valuePair)}
-                  max="100"
-                  decimalPlaces={0}
-                  data-testid="govConfig-quorumPercentage"
-                />
-                <InputRightElement>%</InputRightElement>
-              </InputGroup>
+              <BigIntInput
+                value={values.erc20Token.requiredProposerWeight.bigintValue}
+                onChange={valuePair =>
+                  setFieldValue('erc20Token.requiredProposerWeight', valuePair)
+                }
+                decimalPlaces={18}
+                data-testid="govConfig-proposalPermission"
+              />
             </LabelComponent>
           ) : (
             <LabelComponent
@@ -158,11 +156,10 @@ export function AzoriusGovernance(props: ICreationStepProps) {
               isRequired
             >
               <BigIntInput
-                value={values.erc721Token.quorumThreshold.bigintValue}
-                onChange={valuePair => setFieldValue('erc721Token.quorumThreshold', valuePair)}
+                value={values.erc721Token.proposerThreshold.bigintValue}
+                onChange={valuePair => setFieldValue('erc721Token.proposerThreshold', valuePair)}
                 decimalPlaces={0}
-                min="1"
-                data-testid="govConfig-quorumThreshold"
+                data-testid="govConfig-proposalPermission"
               />
             </LabelComponent>
           )}

--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -133,6 +133,40 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             </LabelComponent>
           )}
 
+          {/* QUORUM */}
+          {values.azorius.votingStrategyType === VotingStrategyType.LINEAR_ERC20 ? (
+            <LabelComponent
+              label={t('proposalPermission', { ns: 'common' })}
+              helper={t('helperProposalPermission')}
+              isRequired
+            >
+              <InputGroup>
+                <BigIntInput
+                  value={values.azorius.quorumPercentage.bigintValue}
+                  onChange={valuePair => setFieldValue('azorius.quorumPercentage', valuePair)}
+                  max="100"
+                  decimalPlaces={0}
+                  data-testid="govConfig-quorumPercentage"
+                />
+                <InputRightElement>%</InputRightElement>
+              </InputGroup>
+            </LabelComponent>
+          ) : (
+            <LabelComponent
+              label={t('proposalPermission', { ns: 'common' })}
+              helper={t('helperProposalPermission')}
+              isRequired
+            >
+              <BigIntInput
+                value={values.erc721Token.quorumThreshold.bigintValue}
+                onChange={valuePair => setFieldValue('erc721Token.quorumThreshold', valuePair)}
+                decimalPlaces={0}
+                min="1"
+                data-testid="govConfig-quorumThreshold"
+              />
+            </LabelComponent>
+          )}
+
           {/* VOTING PERIOD */}
           <LabelComponent
             label={t('labelVotingPeriod')}

--- a/src/components/DaoCreator/hooks/usePrepareFormData.ts
+++ b/src/components/DaoCreator/hooks/usePrepareFormData.ts
@@ -111,6 +111,7 @@ export function usePrepareFormData() {
       tokenAllocations,
       parentAllocationAmount,
       quorumPercentage,
+      requiredProposerWeight,
       timelock,
       votingPeriod,
       executionPeriod,
@@ -151,6 +152,7 @@ export function usePrepareFormData() {
         tokenSupply: tokenSupply.bigintValue!,
         parentAllocationAmount: parentAllocationAmount?.bigintValue!,
         quorumPercentage: quorumPercentage.bigintValue!,
+        requiredProposerWeight: requiredProposerWeight.bigintValue!,
         timelock: await getEstimatedNumberOfBlocks(timelock.bigintValue!, publicClient),
         executionPeriod: await getEstimatedNumberOfBlocks(
           executionPeriod.bigintValue!,
@@ -174,6 +176,7 @@ export function usePrepareFormData() {
   const prepareAzoriusERC721FormData = useCallback(
     async ({
       quorumPercentage,
+      proposerThreshold,
       timelock,
       executionPeriod,
       votingPeriod,
@@ -209,6 +212,7 @@ export function usePrepareFormData() {
 
       return {
         quorumPercentage: quorumPercentage.bigintValue!,
+        proposerThreshold: proposerThreshold.bigintValue!,
         timelock: await getEstimatedNumberOfBlocks(timelock.bigintValue!, publicClient),
         executionPeriod: await getEstimatedNumberOfBlocks(
           executionPeriod.bigintValue!,

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -79,6 +79,7 @@ type DAOGovernorERC20Token<T = bigint> = {
   tokenAllocations: { amount: T; address: string }[];
   parentAllocationAmount: T;
   maxTotalSupply: T;
+  requiredProposerWeight: T;
 };
 
 export interface CreatorFormState<T = BigIntValuePair> {
@@ -104,12 +105,12 @@ export type ERC721TokenConfig<T = bigint> = {
 export type DAOGovernorERC721Token<T = bigint> = {
   nfts: ERC721TokenConfig<T>[];
   quorumThreshold: T;
+  proposerThreshold: T;
 };
 
 export type DAOGovernorModuleConfig<T = bigint> = {
   votingStrategyType: VotingStrategyType;
   quorumPercentage: T;
-  proposalPermission: T;
   timelock: T;
   votingPeriod: T;
   executionPeriod: T;

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -109,6 +109,7 @@ export type DAOGovernorERC721Token<T = bigint> = {
 export type DAOGovernorModuleConfig<T = bigint> = {
   votingStrategyType: VotingStrategyType;
   quorumPercentage: T;
+  proposalPermission: T;
   timelock: T;
   votingPeriod: T;
   executionPeriod: T;


### PR DESCRIPTION
Depends on #3210 

### Summary

* Update the create form type to include the proposal permission field (`requiredProposerWeight` for ERC20, `proposerThreshold` for ERC721).
* Add a proposal permission input in the **Azorius Governance** tab when creating a new DAO.
* Use the proposal permission value from `daoData` (`formValues`) instead of the fixed `1n` in `AzoriusTxBuilder`.
* Add translation keys for the new proposal permission input.

### Screenshot

<img width="2212" height="1660" alt="image" src="https://github.com/user-attachments/assets/f7bf81f5-a575-446b-8909-410e4b08883d" />
