### PR TITLE
`[ENG-1352]` Fix: Chevron drifts for populated 'Select Asset' menu

### DIFF
--- a/public/locales/en/treasury.json
+++ b/public/locales/en/treasury.json
@@ -3,6 +3,7 @@
   "buttonSendAssets": "Request Payment",
   "titleTransactions": "Transactions",
   "titleAssets": "Assets",
+  "titleAssetsWithCount": "Assets ({{count}})",
   "subtitleTreasuryBalance": "Total Treasury Balance",
   "subtitleStaking": "Lido ETH Staking",
   "columnCoins": "Coins",

--- a/src/components/Roles/forms/RoleFormAssetSelector.tsx
+++ b/src/components/Roles/forms/RoleFormAssetSelector.tsx
@@ -101,7 +101,7 @@ export function AssetSelector({ formIndex, disabled }: { formIndex: number; disa
                   setFieldValue(`roleEditing.payments.${formIndex}.asset`, undefined);
                 }
               }}
-              title={t('titleAssets', { ns: 'treasury' })}
+              title={t('titleAssetsWithCount', { ns: 'treasury', count: dropdownItems.length })}
               isDisabled={disabled}
               selectPlaceholder={t('selectLabel', { ns: 'modals' })}
               emptyMessage={t('emptyRolesAssets', { ns: 'roles' })}

--- a/src/components/ui/menus/DropdownMenu.tsx
+++ b/src/components/ui/menus/DropdownMenu.tsx
@@ -223,6 +223,8 @@ export function DropdownMenu<T>({
               px="0.25rem"
               pb="0.25rem"
               w="26.75rem"
+              maxHeight="20rem"
+              overflowY="scroll"
             >
               <EaseOutComponent>
                 {title && (

--- a/src/components/ui/utils/AssetSelector.tsx
+++ b/src/components/ui/utils/AssetSelector.tsx
@@ -110,7 +110,7 @@ export function AssetSelector({
           onSelect?.([item.value]);
         }
       }}
-      title={t('titleAssets', { ns: 'treasury' })}
+      title={t('titleAssetsWithCount', { ns: 'treasury', count: dropdownItems.length })}
       isDisabled={disabled}
       selectPlaceholder={t('selectLabel', { ns: 'modals' })}
       emptyMessage={t('emptyRolesAssets', { ns: 'roles' })}

--- a/src/components/ui/utils/AssetSelector.tsx
+++ b/src/components/ui/utils/AssetSelector.tsx
@@ -143,6 +143,7 @@ export function AssetSelector({
                   w={`${(selectedItems.length - 1) * 0.7 + 6}rem`}
                   className="payment-menu-asset"
                   p="0.5rem"
+                  justify="space-between"
                 >
                   <Flex
                     position="relative"
@@ -163,10 +164,7 @@ export function AssetSelector({
                       />
                     ))}
                   </Flex>
-                  <Flex
-                    alignItems="center"
-                    ml={`${selectedItems.length * 0.8}rem`}
-                  >
+                  <Flex alignItems="center">
                     <Icon
                       color="color-neutral-400"
                       as={CaretDown}


### PR DESCRIPTION
### Summary

* Use `space-between` instead of manually calculating `margin-left` to ensure the CaretDown icon is always correctly positioned on the right.

### Screenshot

#### Before the Fix

<img width="270" height="137" alt="image" src="https://github.com/user-attachments/assets/6ee88202-c860-4b02-ba4d-442a6a08c71b" />

#### After the Fix

<img width="270" height="137" alt="image" src="https://github.com/user-attachments/assets/c6b61106-a523-4bea-8725-a92e31509759" />
