### PR TITLE
`[ENG-1361]` prevent default so dropdown works properly

### DIFF
--- a/src/components/ui/forms/LabelWrapper.tsx
+++ b/src/components/ui/forms/LabelWrapper.tsx
@@ -25,7 +25,11 @@ function LabelWrapper({
 }: LabelWrapperProps) {
   return (
     <Box position="relative">
-      <FormLabel m="0px">
+      <FormLabel 
+        m="0px"
+        onClick={(e) => e.preventDefault()}
+        cursor="default"
+      >
         <Flex
           gap="0.5"
           alignItems="center"

--- a/src/components/ui/forms/LabelWrapper.tsx
+++ b/src/components/ui/forms/LabelWrapper.tsx
@@ -25,9 +25,9 @@ function LabelWrapper({
 }: LabelWrapperProps) {
   return (
     <Box position="relative">
-      <FormLabel 
+      <FormLabel
         m="0px"
-        onClick={(e) => e.preventDefault()}
+        onClick={e => e.preventDefault()}
         cursor="default"
       >
         <Flex


### PR DESCRIPTION
Before you could click anywhere within the assert selector div to activate it, this made it hard to close the asset selector

Was being caused by the label

<img width="1220" height="691" alt="image" src="https://github.com/user-attachments/assets/553b4b31-4a6f-468e-abaa-2cefa9d5388d" />
