### PR TITLE
[`ENG-1362`] Settings modal test ids exploration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,8 @@
         "@typescript-eslint/parser": "^7.0.0",
         "@vitejs/plugin-react": "^4.2.1",
         "@walletconnect/types": "^2.19.2",
+        "concurrently": "^9.2.0",
+        "cross-env": "^10.0.0",
         "eslint": "^8.22.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3768,6 +3770,13 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
       "peer": true
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.2.3",
@@ -12499,6 +12508,120 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -12656,6 +12779,24 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
@@ -12665,9 +12806,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -22606,10 +22748,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
-      "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
-      "peer": true,
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -23770,6 +23915,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "localized": "node scripts/localization_verify.js",
     "pretty": "prettier . --write",
     "pretty:check": "prettier . --check",
-    "dev": "VITE_APP_GIT_HASH=$(git rev-parse --short HEAD) vite",
-    "preview": "VITE_APP_GIT_HASH=$(git rev-parse --short HEAD) vite preview",
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 VITE_APP_GIT_HASH=$(git rev-parse --short HEAD) vite build && NODE_OPTIONS=--max-old-space-size=8192 vite build --mode page-function",
+    "dev": "node scripts/git-hash.js vite",
+    "preview": "node scripts/git-hash.js vite preview",
+    "build": "node scripts/git-hash.js vite build && node scripts/git-hash.js vite build --mode page-function",
     "test": "vitest --dir=test"
   },
   "engines": {
@@ -105,6 +105,8 @@
     "@typescript-eslint/parser": "^7.0.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@walletconnect/types": "^2.19.2",
+    "concurrently": "^9.2.0",
+    "cross-env": "^10.0.0",
     "eslint": "^8.22.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",

--- a/scripts/git-hash.js
+++ b/scripts/git-hash.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const { execSync, spawn } = require('child_process');
+
+function getGitHash() {
+  try {
+    return execSync('git rev-parse --short HEAD', { 
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+  } catch (error) {
+    return 'local-build';
+  }
+}
+
+// If called with arguments, run the command with git hash
+if (process.argv.length > 2) {
+  const gitHash = getGitHash();
+  const command = process.argv[2];
+  const args = process.argv.slice(3);
+  
+  const env = {
+    ...process.env,
+    VITE_APP_GIT_HASH: gitHash
+  };
+  
+  // Add NODE_OPTIONS for build commands
+  if (args.includes('build')) {
+    env.NODE_OPTIONS = '--max-old-space-size=8192';
+  }
+  
+  console.log(`Running ${command} ${args.join(' ')} with git hash: ${gitHash}`);
+  
+  const child = spawn(command, args, {
+    stdio: 'inherit',
+    env,
+    shell: true
+  });
+  
+  child.on('exit', (code) => process.exit(code || 0));
+  child.on('error', (error) => {
+    console.error('Command failed:', error);
+    process.exit(1);
+  });
+} else {
+  // Just output the git hash
+  process.stdout.write(getGitHash());
+}

--- a/scripts/git-hash.js
+++ b/scripts/git-hash.js
@@ -3,9 +3,9 @@ const { execSync, spawn } = require('child_process');
 
 function getGitHash() {
   try {
-    return execSync('git rev-parse --short HEAD', { 
+    return execSync('git rev-parse --short HEAD', {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore']
+      stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
   } catch (error) {
     return 'local-build';
@@ -17,27 +17,27 @@ if (process.argv.length > 2) {
   const gitHash = getGitHash();
   const command = process.argv[2];
   const args = process.argv.slice(3);
-  
+
   const env = {
     ...process.env,
-    VITE_APP_GIT_HASH: gitHash
+    VITE_APP_GIT_HASH: gitHash,
   };
-  
+
   // Add NODE_OPTIONS for build commands
   if (args.includes('build')) {
     env.NODE_OPTIONS = '--max-old-space-size=8192';
   }
-  
+
   console.log(`Running ${command} ${args.join(' ')} with git hash: ${gitHash}`);
-  
+
   const child = spawn(command, args, {
     stdio: 'inherit',
     env,
-    shell: true
+    shell: true,
   });
-  
-  child.on('exit', (code) => process.exit(code || 0));
-  child.on('error', (error) => {
+
+  child.on('exit', code => process.exit(code || 0));
+  child.on('error', error => {
     console.error('Command failed:', error);
     process.exit(1);
   });

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -60,6 +60,7 @@ function WithdrawingGasComponent() {
         color="color-error-500"
         sx={{ '&:disabled:hover': { color: 'inherit', opacity: 0.4 } }}
         type="button"
+        data-testid="gasless-voting-withdraw-remove"
         onClick={() => setFieldValue('paymasterGasTank.withdraw', undefined)}
       />
     </Flex>
@@ -102,6 +103,7 @@ function DepositingGasComponent() {
         color="color-red-500"
         sx={{ '&:disabled:hover': { color: 'inherit', opacity: 0.4 } }}
         type="button"
+        data-testid="gasless-voting-deposit-remove"
         onClick={() => setFieldValue('paymasterGasTank.deposit', undefined)}
       />
     </Flex>
@@ -173,6 +175,7 @@ function GaslessVotingToggleContent({
           isChecked={isEnabled}
           onChange={() => onToggle()}
           variant="secondary"
+          data-testid="gasless-voting-toggle"
         />
       </HStack>
     </Box>
@@ -298,6 +301,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
                     variant="secondary"
                     size="sm"
                     onClick={openWithdrawGasModal}
+                    data-testid="gasless-voting-withdraw-button"
                   >
                     {t('withdrawGas')}
                   </Button>
@@ -305,6 +309,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
                     variant="secondary"
                     size="sm"
                     onClick={openRefillGasModal}
+                    data-testid="gasless-voting-refill-button"
                   >
                     {t('addGas')}
                   </Button>

--- a/src/components/SafeSettings/ERC20TokenContainer.tsx
+++ b/src/components/SafeSettings/ERC20TokenContainer.tsx
@@ -17,10 +17,14 @@ export function ERC20TokenContainer() {
   const { votesToken } = azoriusGovernance;
 
   return (
-    <Box width="100%">
+    <Box
+      width="100%"
+      data-testid="erc20-token-container"
+    >
       <Text
         color="color-white"
         textStyle="text-lg-regular"
+        data-testid="token-info-title"
       >
         {t('governanceTokenInfoTitle')}
       </Text>
@@ -33,6 +37,7 @@ export function ERC20TokenContainer() {
           borderColor="color-neutral-900"
           borderRadius="0.75rem"
           flexDirection="column"
+          data-testid="token-info-content"
         >
           {/* TOKEN NAME */}
           <Flex
@@ -40,12 +45,19 @@ export function ERC20TokenContainer() {
             justifyContent="space-between"
             px={6}
             py={2}
+            data-testid="token-name-row"
           >
-            <Text textStyle="text-base-regular">{t('governanceTokenNameTitle')}</Text>
+            <Text
+              textStyle="text-base-regular"
+              data-testid="token-name-label"
+            >
+              {t('governanceTokenNameTitle')}
+            </Text>
             <DisplayAddress
               mb={-2}
               mr={-4}
               address={votesToken.address}
+              data-testid="token-name-value"
             >
               {votesToken.name}
             </DisplayAddress>
@@ -59,11 +71,18 @@ export function ERC20TokenContainer() {
             justifyContent="space-between"
             px={6}
             py={2}
+            data-testid="token-symbol-row"
           >
-            <Text textStyle="text-base-regular">{t('governanceTokenSymbolLabel')}</Text>
+            <Text
+              textStyle="text-base-regular"
+              data-testid="token-symbol-label"
+            >
+              {t('governanceTokenSymbolLabel')}
+            </Text>
             <Text
               color="color-neutral-300"
               textStyle="text-base-regular"
+              data-testid="token-symbol-value"
             >
               ${votesToken.symbol}
             </Text>
@@ -77,11 +96,18 @@ export function ERC20TokenContainer() {
             justifyContent="space-between"
             px={6}
             py={2}
+            data-testid="token-supply-row"
           >
-            <Text textStyle="text-base-regular">{t('governanceTokenSupplyLabel')}</Text>
+            <Text
+              textStyle="text-base-regular"
+              data-testid="token-supply-label"
+            >
+              {t('governanceTokenSupplyLabel')}
+            </Text>
             <Text
               color="color-neutral-300"
               textStyle="text-base-regular"
+              data-testid="token-supply-value"
             >
               {formatCoin(
                 votesToken.totalSupply,
@@ -99,6 +125,7 @@ export function ERC20TokenContainer() {
           justifyContent="center"
           alignItems="center"
           minHeight="100px"
+          data-testid="token-loading"
         >
           <BarLoader />
         </Flex>

--- a/src/components/SafeSettings/ERC721TokensContainer.tsx
+++ b/src/components/SafeSettings/ERC721TokensContainer.tsx
@@ -16,10 +16,14 @@ export function ERC721TokensContainer() {
   const { erc721Tokens } = azoriusGovernance;
 
   return (
-    <Box width="100%">
+    <Box
+      width="100%"
+      data-testid="erc721-tokens-container"
+    >
       <Text
         color="color-white"
         textStyle="text-lg-regular"
+        data-testid="token-info-title"
       >
         {t('governanceTokenInfoTitle')}
       </Text>
@@ -32,21 +36,32 @@ export function ERC721TokensContainer() {
           borderColor="color-neutral-900"
           borderRadius="0.75rem"
           flexDirection="column"
+          data-testid="erc721-tokens-content"
         >
           {erc721Tokens.map((token, index) => (
-            <Box key={token.address}>
+            <Box
+              key={token.address}
+              data-testid={`erc721-token-${index}`}
+            >
               {/* TOKEN NAME */}
               <Flex
                 alignItems="center"
                 justifyContent="space-between"
                 px={6}
                 py={2}
+                data-testid={`erc721-token-name-row-${index}`}
               >
-                <Text textStyle="text-base-regular">{t('governanceTokenNameTitle')}</Text>
+                <Text
+                  textStyle="text-base-regular"
+                  data-testid={`erc721-token-name-label-${index}`}
+                >
+                  {t('governanceTokenNameTitle')}
+                </Text>
                 <DisplayAddress
                   mb={-2}
                   mr={-4}
                   address={token.address}
+                  data-testid={`erc721-token-name-value-${index}`}
                 >
                   {token.name}
                 </DisplayAddress>
@@ -60,11 +75,18 @@ export function ERC721TokensContainer() {
                 justifyContent="space-between"
                 px={6}
                 py={2}
+                data-testid={`erc721-token-symbol-row-${index}`}
               >
-                <Text textStyle="text-base-regular">{t('governanceTokenSymbolLabel')}</Text>
+                <Text
+                  textStyle="text-base-regular"
+                  data-testid={`erc721-token-symbol-label-${index}`}
+                >
+                  {t('governanceTokenSymbolLabel')}
+                </Text>
                 <Text
                   color="color-neutral-300"
                   textStyle="text-base-regular"
+                  data-testid={`erc721-token-symbol-value-${index}`}
                 >
                   ${token.symbol}
                 </Text>
@@ -78,11 +100,18 @@ export function ERC721TokensContainer() {
                 justifyContent="space-between"
                 px={6}
                 py={2}
+                data-testid={`erc721-voting-weight-row-${index}`}
               >
-                <Text textStyle="text-base-regular">{t('governanceTokenWeightLabel')}</Text>
+                <Text
+                  textStyle="text-base-regular"
+                  data-testid={`erc721-voting-weight-label-${index}`}
+                >
+                  {t('governanceTokenWeightLabel')}
+                </Text>
                 <Text
                   color="color-neutral-300"
                   textStyle="text-base-regular"
+                  data-testid={`erc721-voting-weight-value-${index}`}
                 >
                   {token.votingWeight.toString()}
                 </Text>
@@ -96,11 +125,18 @@ export function ERC721TokensContainer() {
                 justifyContent="space-between"
                 px={6}
                 py={2}
+                data-testid={`erc721-total-weight-row-${index}`}
               >
-                <Text textStyle="text-base-regular">{t('governanceTokenTotalWeightLabel')}</Text>
+                <Text
+                  textStyle="text-base-regular"
+                  data-testid={`erc721-total-weight-label-${index}`}
+                >
+                  {t('governanceTokenTotalWeightLabel')}
+                </Text>
                 <Text
                   color="color-neutral-300"
                   textStyle="text-base-regular"
+                  data-testid={`erc721-total-weight-value-${index}`}
                 >
                   {token.totalSupply ? (token.totalSupply * token.votingWeight).toString() : 'n/a'}
                 </Text>
@@ -115,6 +151,7 @@ export function ERC721TokensContainer() {
           justifyContent="center"
           alignItems="center"
           minHeight="100px"
+          data-testid="erc721-loading"
         >
           <BarLoader />
         </Flex>

--- a/src/components/SafeSettings/SafePermissionsStrategyAction.tsx
+++ b/src/components/SafeSettings/SafePermissionsStrategyAction.tsx
@@ -28,26 +28,45 @@ export function SafePermissionsStrategyAction({
     <Box
       width="100%"
       whiteSpace="balance"
+      data-testid="permissions-strategy-action"
     >
-      <Text as="span">{title}</Text>
+      <Text
+        as="span"
+        data-testid="permissions-action-title"
+      >
+        {title}
+      </Text>
       <Text
         color="color-lilac-100"
         as="span"
+        data-testid="permissions-create-proposals-text"
       >
         {` ${t('createProposals')} `}
       </Text>
-      <Text as="span">{` ${t('editPermissionActionDescription')} `}</Text>
+      <Text
+        as="span"
+        data-testid="permissions-action-description"
+      >
+        {` ${t('editPermissionActionDescription')} `}
+      </Text>
       <Icon
         as={Coins}
         color="color-lilac-100"
+        data-testid="permissions-threshold-icon"
       />
       <Text
         as="span"
         color="color-lilac-100"
+        data-testid="permissions-threshold-value"
       >
         {` ${proposerThreshold.value} ${azoriusGovernance.votesToken?.symbol || t('votingWeightThreshold')} `}
       </Text>
-      <Text as="span">{` ${t('editPermissionActionDescription2')} `}</Text>
+      <Text
+        as="span"
+        data-testid="permissions-action-description-2"
+      >
+        {` ${t('editPermissionActionDescription2')} `}
+      </Text>
     </Box>
   );
 }

--- a/src/components/SafeSettings/SettingsContentBox.tsx
+++ b/src/components/SafeSettings/SettingsContentBox.tsx
@@ -10,6 +10,7 @@ export function SettingsContentBox({ children, ...props }: PropsWithChildren<Box
       borderBottomLeftRadius={{ base: '0.75rem', md: '0' }}
       overflowY="auto"
       scrollPaddingY={4}
+      data-testid="settings-content-box"
       {...props}
     >
       {children}

--- a/src/components/SafeSettings/SettingsPermissionsStrategyForm.tsx
+++ b/src/components/SafeSettings/SettingsPermissionsStrategyForm.tsx
@@ -29,24 +29,41 @@ export function SettingsPermissionsStrategyForm({
     <Flex
       flexDirection="column"
       gap={6}
+      data-testid="permissions-strategy-form"
     >
       <Flex
         flexDirection="column"
         gap={2}
         align="flex-start"
+        data-testid="permissions-asset-section"
       >
         <Flex
           gap={1}
           alignItems="center"
           ref={tooltipContainerRef}
+          data-testid="permissions-asset-header"
         >
-          <Text textStyle="text-xl-regular">{t('asset')}</Text>
-          <Text color="color-lilac-100">*</Text>
+          <Text
+            textStyle="text-xl-regular"
+            data-testid="permissions-asset-title"
+          >
+            {t('asset')}
+          </Text>
+          <Text
+            color="color-lilac-100"
+            data-testid="permissions-asset-required-indicator"
+          >
+            *
+          </Text>
           <ModalTooltip
             containerRef={tooltipContainerRef}
             label={t('assetTooltip')}
+            data-testid="permissions-asset-tooltip"
           >
-            <Box color="color-lilac-100">
+            <Box
+              color="color-lilac-100"
+              data-testid="permissions-asset-tooltip-icon"
+            >
               <Info />
             </Box>
           </ModalTooltip>
@@ -55,6 +72,7 @@ export function SettingsPermissionsStrategyForm({
           variant="unstyled"
           isDisabled
           p={0}
+          data-testid="permissions-asset-button"
         >
           <Flex
             gap={3}
@@ -65,15 +83,18 @@ export function SettingsPermissionsStrategyForm({
             w="fit-content"
             className="payment-menu-asset"
             p={2}
+            data-testid="permissions-asset-display"
           >
             <Image
               // @todo: Add asset logo
               src="/images/coin-icon-default.svg"
               boxSize="2.25rem"
+              data-testid="permissions-asset-image"
             />
             <Text
               textStyle="text-base-regular"
               color="color-white"
+              data-testid="permissions-asset-text"
             >
               {votesToken?.symbol || erc721Tokens?.map(token => token.symbol).join(', ')}
             </Text>
@@ -83,11 +104,13 @@ export function SettingsPermissionsStrategyForm({
       <LabelWrapper
         label={t('permissionAmountLabel')}
         labelColor="color-neutral-300"
+        data-testid="permissions-amount-section"
       >
         <BigIntInput
           onChange={setProposerThreshold}
           decimalPlaces={votesToken ? votesToken.decimals : 0}
           value={proposerThreshold.bigintValue}
+          data-testid="permissions-amount-input"
         />
       </LabelWrapper>
     </Flex>

--- a/src/components/SafeSettings/Signers/SignersContainer.tsx
+++ b/src/components/SafeSettings/Signers/SignersContainer.tsx
@@ -34,11 +34,13 @@ function Signer({
   onRemove,
   markedForRemoval,
   canRemove,
+  index,
 }: {
   signer: SignerItem;
   onRemove: (() => void) | null;
   markedForRemoval?: boolean;
   canRemove: boolean;
+  index: number;
 }) {
   if (!signer.isAdding && !signer.address) {
     throw new Error('Signer does not have an address');
@@ -60,6 +62,7 @@ function Signer({
     <Flex
       flexDirection="column"
       alignItems="stretch"
+      data-testid={`signer-item-${index}`}
     >
       <Flex
         flexDirection="row"
@@ -76,6 +79,7 @@ function Signer({
           textDecoration={markedForRemoval ? 'line-through' : 'none'}
           color={!!newSigner ? 'color-white' : 'color-neutral-900'}
           isInvalid={isInvalid}
+          data-testid={`signer-input-${index}`}
           onChange={e => {
             // Find and overwrite the address input value of this new signer with the input value
             const newSigners = values.multisig?.newSigners?.map((s: NewSignerItem) =>
@@ -100,6 +104,7 @@ function Signer({
             h="1.5rem"
             p="0"
             isDisabled={!showRemoveButton}
+            data-testid={`signer-remove-${index}`}
             onClick={onRemove ?? (() => {})}
           >
             <Icon
@@ -116,6 +121,7 @@ function Signer({
             aria-label="Remove Signer"
             h="1.5rem"
             p="0"
+            data-testid={`signer-restore-${index}`}
             onClick={() => {
               setFieldValue('multisig.signersToRemove', [
                 ...(values.multisig?.signersToRemove ?? []).filter(
@@ -201,7 +207,10 @@ export function SignersContainer() {
   }, [signers, values.multisig?.signersToRemove, values.multisig?.newSigners]);
 
   return (
-    <Box width="100%">
+    <Box
+      width="100%"
+      data-testid="signers-container"
+    >
       {/* LAUNCH TOKEN BANNER */}
       <Flex
         flexDirection="row"
@@ -211,6 +220,7 @@ export function SignersContainer() {
         mb={12}
         justifyContent="space-between"
         alignItems="center"
+        data-testid="launch-token-banner"
       >
         <Flex
           flexDirection="row"
@@ -221,6 +231,7 @@ export function SignersContainer() {
             src="/images/token-banner.svg"
             w="3.52244rem"
             h="3.75rem"
+            data-testid="launch-token-banner-image"
           />
           <Flex
             mt={4}
@@ -230,6 +241,7 @@ export function SignersContainer() {
               textStyle="text-xs-medium"
               color="color-lilac-700"
               fontWeight="bold"
+              data-testid="launch-token-title"
             >
               {t('launchTokenTitle', { ns: 'daoEdit' })}
             </Text>
@@ -237,6 +249,7 @@ export function SignersContainer() {
               textStyle="text-sm-medium"
               color="color-lilac-700"
               mb="1rem"
+              data-testid="launch-token-description"
             >
               {t('launchTokenDescription', { ns: 'daoEdit' })}
             </Text>
@@ -246,6 +259,7 @@ export function SignersContainer() {
           bg="color-white"
           _hover={{ bg: 'color-white' }}
           size="sm"
+          data-testid="launch-token-button"
           onClick={handleModifyGovernance}
         >
           {t('launchToken', { ns: 'daoEdit' })}
@@ -256,6 +270,7 @@ export function SignersContainer() {
         textStyle="text-lg-regular"
         color="color-white"
         mb={0.5}
+        data-testid="owners-section-title"
       >
         {t('owners', { ns: 'common' })}
       </Text>
@@ -264,11 +279,13 @@ export function SignersContainer() {
         border="1px solid"
         borderColor="color-neutral-900"
         borderRadius="0.75rem"
+        data-testid="owners-section"
       >
-        {signers.map(signer => (
+        {signers.map((signer, index) => (
           <Signer
             key={signer.key}
             signer={signer}
+            index={index}
             markedForRemoval={values.multisig?.signersToRemove?.includes(signer.address) ?? false}
             onRemove={
               enableRemove
@@ -283,10 +300,11 @@ export function SignersContainer() {
             canRemove={canRemoveMoreSigners}
           />
         ))}
-        {values.multisig?.newSigners?.map(signer => (
+        {values.multisig?.newSigners?.map((signer, index) => (
           <Signer
             key={signer.key}
             signer={signer}
+            index={signers.length + index}
             onRemove={() => {
               setFieldValue(
                 'multisig.newSigners',
@@ -303,10 +321,12 @@ export function SignersContainer() {
             justifyContent="flex-end"
             px={6}
             py={2}
+            data-testid="add-signer-section"
           >
             <Button
               variant="secondary"
               size="sm"
+              data-testid="signer-add-button"
               onClick={() => {
                 const key = genSignerItemKey();
                 setFieldValue('multisig.newSigners', [
@@ -332,6 +352,7 @@ export function SignersContainer() {
         mt={3}
         px={6}
         py={3}
+        data-testid="threshold-section"
       >
         <Flex
           flexDirection="row"
@@ -343,12 +364,14 @@ export function SignersContainer() {
             <Text
               textStyle="text-lg-regular"
               mb={0.5}
+              data-testid="threshold-title"
             >
               {t('threshold', { ns: 'common' })}
             </Text>
             <Text
               textStyle="text-base-regular"
               color="color-neutral-300"
+              data-testid="threshold-description"
             >
               {t('thresholdDescription', { ns: 'common' })}
             </Text>
@@ -357,6 +380,7 @@ export function SignersContainer() {
           {/* stepper */}
           <Flex w="200px">
             <NumberStepperInput
+              data-testid="threshold-input"
               onChange={value => {
                 let updatedValue;
                 if (value !== `${safe?.threshold}`) {

--- a/src/components/SafeSettings/Signers/modals/AddSignerModal.tsx
+++ b/src/components/SafeSettings/Signers/modals/AddSignerModal.tsx
@@ -87,9 +87,7 @@ function AddSignerModal({
         {({ handleSubmit, errors, values, setFieldValue }) => {
           return (
             <form onSubmit={handleSubmit}>
-              <Text data-testid="add-signer-label">
-                {t('addSignerLabel', { ns: 'modals' })}
-              </Text>
+              <Text data-testid="add-signer-label">{t('addSignerLabel', { ns: 'modals' })}</Text>
               <Field name={'address'}>
                 {({ field }: FieldAttributes<any>) => (
                   <LabelWrapper

--- a/src/components/SafeSettings/Signers/modals/AddSignerModal.tsx
+++ b/src/components/SafeSettings/Signers/modals/AddSignerModal.tsx
@@ -73,7 +73,7 @@ function AddSignerModal({
   });
 
   return (
-    <Box>
+    <Box data-testid="add-signer-modal">
       <Formik
         initialValues={{
           address: '',
@@ -87,7 +87,9 @@ function AddSignerModal({
         {({ handleSubmit, errors, values, setFieldValue }) => {
           return (
             <form onSubmit={handleSubmit}>
-              <Text>{t('addSignerLabel', { ns: 'modals' })}</Text>
+              <Text data-testid="add-signer-label">
+                {t('addSignerLabel', { ns: 'modals' })}
+              </Text>
               <Field name={'address'}>
                 {({ field }: FieldAttributes<any>) => (
                   <LabelWrapper
@@ -97,6 +99,7 @@ function AddSignerModal({
                     <AddressInput
                       {...field}
                       isInvalid={!!field.value && !!errors.address}
+                      data-testid="add-signer-address-input"
                     />
                   </LabelWrapper>
                 )}
@@ -105,8 +108,10 @@ function AddSignerModal({
                 mt={6}
                 mb={4}
               />
-              <HStack>
-                <Text>{t('updateThreshold', { ns: 'modals' })}</Text>
+              <HStack data-testid="threshold-section">
+                <Text data-testid="threshold-section-title">
+                  {t('updateThreshold', { ns: 'modals' })}
+                </Text>
                 <Flex ref={tooltipContainer}>
                   <SupportTooltip
                     containerRef={tooltipContainer}
@@ -114,10 +119,11 @@ function AddSignerModal({
                     label={t('updateSignersTooltip')}
                     mx="2"
                     mt="1"
+                    data-testid="add-signer-threshold-tooltip"
                   />
                 </Flex>
               </HStack>
-              <HStack>
+              <HStack data-testid="threshold-controls">
                 <Select
                   onChange={e => setFieldValue('threshold', Number(e.target.value))}
                   mt={4}
@@ -126,11 +132,13 @@ function AddSignerModal({
                   borderColor="color-neutral-900"
                   rounded="sm"
                   cursor="pointer"
+                  data-testid="add-signer-threshold-select"
                 >
                   {values.thresholdOptions?.map(thresholdOption => (
                     <option
                       key={thresholdOption}
                       value={thresholdOption}
+                      data-testid={`add-signer-threshold-option-${thresholdOption}`}
                     >
                       {thresholdOption}
                     </option>
@@ -140,6 +148,7 @@ function AddSignerModal({
                   <Text
                     mt={3}
                     ml={2}
+                    data-testid="threshold-description"
                   >{`${t('signersRequired1', { ns: 'modals' })} ${signers.length + 1} ${t(
                     'signersRequired2',
                     { ns: 'modals' },
@@ -157,15 +166,18 @@ function AddSignerModal({
                 borderRadius="0.25rem"
                 alignItems="center"
                 gap="1rem"
+                data-testid="add-signer-warning"
               >
                 <Icon
                   color="color-yellow-200"
                   as={WarningCircle}
                   boxSize="1.5rem"
+                  data-testid="add-signer-warning-icon"
                 />
                 <Text
                   color="color-yellow-200"
                   whiteSpace="pre-wrap"
+                  data-testid="add-signer-warning-text"
                 >
                   {t('updateSignerWarning', { ns: 'modals' })}
                 </Text>
@@ -175,12 +187,14 @@ function AddSignerModal({
               <CustomNonceInput
                 nonce={values.nonce}
                 onChange={newNonce => setFieldValue('nonce', newNonce)}
+                data-testid="add-signer-nonce-input"
               />
               <Button
                 type="submit"
                 isDisabled={!!Object.keys(errors).length || !safe}
                 mt={6}
                 width="100%"
+                data-testid="add-signer-submit"
               >
                 {t('createProposal', { ns: 'modals' })}
               </Button>

--- a/src/components/SafeSettings/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/SafeSettings/Signers/modals/RemoveSignerModal.tsx
@@ -64,22 +64,30 @@ function RemoveSignerModal({
   }, [selectedSigner, signers]);
 
   return (
-    <Box>
-      <Text textStyle="text-sm-medium">{t('removeSignerLabel', { ns: 'modals' })}</Text>
+    <Box data-testid="remove-signer-modal">
+      <Text
+        textStyle="text-sm-medium"
+        data-testid="remove-signer-label"
+      >
+        {t('removeSignerLabel', { ns: 'modals' })}
+      </Text>
       <Input
         value={ensName ? ensName : selectedSigner}
         disabled={true}
         my="0.5rem"
+        data-testid="remove-signer-address-input"
       />
-      <HStack>
+      <HStack data-testid="remove-signer-warning-section">
         <Icon
           weight="fill"
           as={WarningDiamond}
           color="color-error-500"
+          data-testid="remove-signer-warning-icon"
         />
         <Text
           textStyle="text-sm-medium"
           color="color-error-500"
+          data-testid="remove-signer-warning-text"
         >
           {t('removeSignerWarning', { ns: 'modals' })}
         </Text>
@@ -89,8 +97,10 @@ function RemoveSignerModal({
         mt={5}
         mb={4}
       />
-      <HStack>
-        <Text>{t('updateThreshold', { ns: 'modals' })}</Text>
+      <HStack data-testid="threshold-section">
+        <Text data-testid="threshold-section-title">
+          {t('updateThreshold', { ns: 'modals' })}
+        </Text>
         <Flex ref={tooltipContainer}>
           <SupportTooltip
             containerRef={tooltipContainer}
@@ -98,11 +108,12 @@ function RemoveSignerModal({
             color="color-lilac-100"
             mx="2"
             mt="1"
+            data-testid="remove-signer-threshold-tooltip"
           />
         </Flex>
       </HStack>
 
-      <HStack>
+      <HStack data-testid="threshold-controls">
         <Select
           onChange={e => setThreshold(Number(e.target.value))}
           mt={4}
@@ -111,11 +122,13 @@ function RemoveSignerModal({
           borderColor="color-neutral-900"
           rounded="sm"
           cursor="pointer"
+          data-testid="remove-signer-threshold-select"
         >
           {thresholdOptions?.map(thresholdOption => (
             <option
               key={thresholdOption}
               value={thresholdOption}
+              data-testid={`remove-signer-threshold-option-${thresholdOption}`}
             >
               {thresholdOption}
             </option>
@@ -125,6 +138,7 @@ function RemoveSignerModal({
           <Text
             mt={3}
             ml={2}
+            data-testid="threshold-description"
           >{`${t('signersRequired1', { ns: 'modals' })} ${signers.length - 1} ${t(
             'signersRequired2',
             { ns: 'modals' },
@@ -141,15 +155,18 @@ function RemoveSignerModal({
         borderRadius="0.25rem"
         alignItems="center"
         gap="1rem"
+        data-testid="remove-signer-warning-box"
       >
         <Icon
           color="color-yellow-200"
           as={WarningCircle}
           boxSize="1.5rem"
+          data-testid="remove-signer-warning-box-icon"
         />
         <Text
           color="color-yellow-200"
           whiteSpace="pre-wrap"
+          data-testid="remove-signer-warning-box-text"
         >
           {t('updateSignerWarning', { ns: 'modals' })}
         </Text>
@@ -161,12 +178,14 @@ function RemoveSignerModal({
       <CustomNonceInput
         nonce={nonce}
         onChange={newNonce => setNonce(newNonce !== undefined ? parseInt(newNonce) : undefined)}
+        data-testid="remove-signer-nonce-input"
       />
       <Button
         isDisabled={!threshold || !nonce || !safe || nonce < safe.nonce}
         mt={6}
         width="100%"
         onClick={onSubmit}
+        data-testid="remove-signer-submit"
       >
         {t('createProposal', { ns: 'modals' })}
       </Button>

--- a/src/components/SafeSettings/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/SafeSettings/Signers/modals/RemoveSignerModal.tsx
@@ -98,9 +98,7 @@ function RemoveSignerModal({
         mb={4}
       />
       <HStack data-testid="threshold-section">
-        <Text data-testid="threshold-section-title">
-          {t('updateThreshold', { ns: 'modals' })}
-        </Text>
+        <Text data-testid="threshold-section-title">{t('updateThreshold', { ns: 'modals' })}</Text>
         <Flex ref={tooltipContainer}>
           <SupportTooltip
             containerRef={tooltipContainer}

--- a/src/components/ui/forms/BigIntInput.tsx
+++ b/src/components/ui/forms/BigIntInput.tsx
@@ -20,6 +20,7 @@ export interface BigIntInputProps
   max?: string;
   maxValue?: bigint;
   parentFormikValue?: BigIntValuePair;
+  'data-testid'?: string;
 }
 /**
  * This component will add a chakra Input component that accepts and sets a bigint
@@ -44,6 +45,7 @@ export function BigIntInput({
   max,
   maxValue,
   parentFormikValue = { value: '', bigintValue: undefined },
+  'data-testid': testId,
   ...rest
 }: BigIntInputProps) {
   const { t } = useTranslation('common');
@@ -184,6 +186,7 @@ export function BigIntInput({
           e.currentTarget.blur();
         }}
         type="number"
+        data-testid={testId}
         {...rest}
       />
       {maxValue !== undefined && (
@@ -200,6 +203,7 @@ export function BigIntInput({
             }}
             variant="text"
             size="md"
+            data-testid={testId ? `${testId}-max` : undefined}
           >
             {t('max')}
           </Button>

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -48,6 +48,7 @@ export default function DurationUnitStepperInput({
   color = 'color-white',
   hideSteppers = false,
   placeholder = '0',
+  'data-testid': testId,
 }: {
   secondsValue: number | undefined;
   onSecondsValueChange: (val: number | undefined) => void;
@@ -55,6 +56,7 @@ export default function DurationUnitStepperInput({
   color?: string;
   hideSteppers?: boolean;
   placeholder?: string;
+  'data-testid'?: string;
 }) {
   const { t } = useTranslation('common');
 
@@ -96,14 +98,20 @@ export default function DurationUnitStepperInput({
       onChange={val => onSecondsValueChange(Number(val) * selectedUnit.unit)}
       min={minSeconds / selectedUnit.unit}
       focusInputOnChange
+      data-testid={testId}
     >
       <HStack gap="0.25rem">
-        {!hideSteppers && <NumberDecrementStepper>{stepperButton('dec')}</NumberDecrementStepper>}
+        {!hideSteppers && (
+          <NumberDecrementStepper data-testid={testId ? `${testId}-decrement` : undefined}>
+            {stepperButton('dec')}
+          </NumberDecrementStepper>
+        )}
         <InputGroup>
           <NumberInputField
             min={0}
             color={color}
             placeholder={placeholder}
+            data-testid={testId ? `${testId}-input` : undefined}
           />
           <InputRightElement
             color="color-neutral-700"
@@ -117,6 +125,7 @@ export default function DurationUnitStepperInput({
               rounded="lg"
               cursor="pointer"
               border="none"
+              data-testid={testId ? `${testId}-unit-select` : undefined}
               sx={{
                 _focusVisible: {
                   boxShadow: 'none',

--- a/src/components/ui/forms/NumberStepperInput.tsx
+++ b/src/components/ui/forms/NumberStepperInput.tsx
@@ -19,6 +19,7 @@ export function NumberStepperInput({
   disabled,
   isInvalid,
   color,
+  'data-testid': testId,
 }: {
   value?: string | number;
   onChange: (val: string) => void;
@@ -26,6 +27,7 @@ export function NumberStepperInput({
   disabled?: boolean;
   isInvalid?: boolean;
   color?: string;
+  'data-testid'?: string;
 }) {
   const stepperButton = (direction: 'inc' | 'dec') => (
     <Button
@@ -47,17 +49,23 @@ export function NumberStepperInput({
       focusInputOnChange
       isDisabled={disabled}
       isInvalid={isInvalid}
+      data-testid={testId}
     >
       <HStack gap="0.25rem">
-        <NumberDecrementStepper>{stepperButton('dec')}</NumberDecrementStepper>
+        <NumberDecrementStepper data-testid={testId ? `${testId}-decrement` : undefined}>
+          {stepperButton('dec')}
+        </NumberDecrementStepper>
         <InputGroup>
           <NumberInputField
             color={color}
             min={0}
+            data-testid={testId ? `${testId}-input` : undefined}
           />
           <InputRightElement mr="1rem">{rightElement}</InputRightElement>
         </InputGroup>
-        <NumberIncrementStepper>{stepperButton('inc')}</NumberIncrementStepper>
+        <NumberIncrementStepper data-testid={testId ? `${testId}-increment` : undefined}>
+          {stepperButton('inc')}
+        </NumberIncrementStepper>
       </HStack>
     </NumberInput>
   );

--- a/src/components/ui/menus/DropdownMenu.tsx
+++ b/src/components/ui/menus/DropdownMenu.tsx
@@ -37,6 +37,7 @@ interface DropdownMenuProps<T = {}> {
   renderItem?: (item: DropdownItem<T>, isSelected: boolean) => React.ReactNode;
   renderButton?: () => React.ReactNode;
   closeOnSelect?: boolean;
+  'data-testid'?: string;
 }
 
 export function DropdownMenu<T>({
@@ -50,6 +51,7 @@ export function DropdownMenu<T>({
   renderItem,
   renderButton,
   closeOnSelect = true,
+  'data-testid': testId,
 }: DropdownMenuProps<T>) {
   return (
     <Menu
@@ -69,6 +71,7 @@ export function DropdownMenu<T>({
               isDisabled={isDisabled}
               cursor={isDisabled ? 'not-allowed' : 'pointer'}
               p={0}
+              data-testid={testId}
               sx={{
                 '&:disabled': {
                   '.payment-menu-asset *': {

--- a/src/components/ui/modals/AddStrategyPermissionModal.tsx
+++ b/src/components/ui/modals/AddStrategyPermissionModal.tsx
@@ -27,12 +27,14 @@ export function AddStrategyPermissionModal({
       gap={4}
       flexDirection="column"
       px={{ base: 4, md: 0 }}
+      data-testid="add-strategy-permission-modal"
     >
       <Flex
         justifyContent="space-between"
         alignItems="center"
+        data-testid="add-strategy-permission-header"
       >
-        <Text textStyle="text-xl-regular">{t('addPermissionTitle')}</Text>
+        <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-title">{t('addPermissionTitle')}</Text>
         <Show above="md">
           <IconButton
             variant="ghost"
@@ -40,10 +42,11 @@ export function AddStrategyPermissionModal({
             aria-label={t('close', { ns: 'common' })}
             onClick={closeModal}
             icon={<X size={24} />}
+            data-testid="add-strategy-permission-close-button"
           />
         </Show>
       </Flex>
-      <Flex gap={2}>
+      <Flex gap={2} data-testid="add-strategy-permission-options">
         <Card
           display="flex"
           flexDirection="column"
@@ -56,16 +59,18 @@ export function AddStrategyPermissionModal({
             closeModal();
             openAddCreateProposalPermissionModal();
           }}
+          data-testid="add-strategy-permission-create-proposals-card"
         >
-          <Box color="color-lilac-100">
+          <Box color="color-lilac-100" data-testid="add-strategy-permission-create-proposals-icon">
             <Scroll size={24} />
           </Box>
           <Flex
             flexDirection="column"
             gap={1}
+            data-testid="add-strategy-permission-create-proposals-content"
           >
-            <Text textStyle="text-xl-regular">{t('permissionCreateProposalsTitle')}</Text>
-            <Text color="color-neutral-300">{t('permissionCreateProposalsDescription')}</Text>
+            <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-create-proposals-title">{t('permissionCreateProposalsTitle')}</Text>
+            <Text color="color-neutral-300" data-testid="add-strategy-permission-create-proposals-description">{t('permissionCreateProposalsDescription')}</Text>
           </Flex>
         </Card>
 
@@ -75,17 +80,19 @@ export function AddStrategyPermissionModal({
           gap={2}
           _hover={{}}
           cursor="not-allowed"
+          data-testid="add-strategy-permission-coming-soon-card"
         >
-          <Box color="color-neutral-400">
+          <Box color="color-neutral-400" data-testid="add-strategy-permission-coming-soon-icon">
             <CheckSquare size={24} />
           </Box>
           <Flex
             flexDirection="column"
             gap={1}
             color="color-neutral-400"
+            data-testid="add-strategy-permission-coming-soon-content"
           >
-            <Text textStyle="text-xl-regular">{t('permissionComingSoonTitle')}</Text>
-            <Text>{t('permissionComingSoonDescription')}</Text>
+            <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-coming-soon-title">{t('permissionComingSoonTitle')}</Text>
+            <Text data-testid="add-strategy-permission-coming-soon-description">{t('permissionComingSoonDescription')}</Text>
           </Flex>
         </Card>
       </Flex>

--- a/src/components/ui/modals/AddStrategyPermissionModal.tsx
+++ b/src/components/ui/modals/AddStrategyPermissionModal.tsx
@@ -34,7 +34,12 @@ export function AddStrategyPermissionModal({
         alignItems="center"
         data-testid="add-strategy-permission-header"
       >
-        <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-title">{t('addPermissionTitle')}</Text>
+        <Text
+          textStyle="text-xl-regular"
+          data-testid="add-strategy-permission-title"
+        >
+          {t('addPermissionTitle')}
+        </Text>
         <Show above="md">
           <IconButton
             variant="ghost"
@@ -46,7 +51,10 @@ export function AddStrategyPermissionModal({
           />
         </Show>
       </Flex>
-      <Flex gap={2} data-testid="add-strategy-permission-options">
+      <Flex
+        gap={2}
+        data-testid="add-strategy-permission-options"
+      >
         <Card
           display="flex"
           flexDirection="column"
@@ -61,7 +69,10 @@ export function AddStrategyPermissionModal({
           }}
           data-testid="add-strategy-permission-create-proposals-card"
         >
-          <Box color="color-lilac-100" data-testid="add-strategy-permission-create-proposals-icon">
+          <Box
+            color="color-lilac-100"
+            data-testid="add-strategy-permission-create-proposals-icon"
+          >
             <Scroll size={24} />
           </Box>
           <Flex
@@ -69,8 +80,18 @@ export function AddStrategyPermissionModal({
             gap={1}
             data-testid="add-strategy-permission-create-proposals-content"
           >
-            <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-create-proposals-title">{t('permissionCreateProposalsTitle')}</Text>
-            <Text color="color-neutral-300" data-testid="add-strategy-permission-create-proposals-description">{t('permissionCreateProposalsDescription')}</Text>
+            <Text
+              textStyle="text-xl-regular"
+              data-testid="add-strategy-permission-create-proposals-title"
+            >
+              {t('permissionCreateProposalsTitle')}
+            </Text>
+            <Text
+              color="color-neutral-300"
+              data-testid="add-strategy-permission-create-proposals-description"
+            >
+              {t('permissionCreateProposalsDescription')}
+            </Text>
           </Flex>
         </Card>
 
@@ -82,7 +103,10 @@ export function AddStrategyPermissionModal({
           cursor="not-allowed"
           data-testid="add-strategy-permission-coming-soon-card"
         >
-          <Box color="color-neutral-400" data-testid="add-strategy-permission-coming-soon-icon">
+          <Box
+            color="color-neutral-400"
+            data-testid="add-strategy-permission-coming-soon-icon"
+          >
             <CheckSquare size={24} />
           </Box>
           <Flex
@@ -91,8 +115,15 @@ export function AddStrategyPermissionModal({
             color="color-neutral-400"
             data-testid="add-strategy-permission-coming-soon-content"
           >
-            <Text textStyle="text-xl-regular" data-testid="add-strategy-permission-coming-soon-title">{t('permissionComingSoonTitle')}</Text>
-            <Text data-testid="add-strategy-permission-coming-soon-description">{t('permissionComingSoonDescription')}</Text>
+            <Text
+              textStyle="text-xl-regular"
+              data-testid="add-strategy-permission-coming-soon-title"
+            >
+              {t('permissionComingSoonTitle')}
+            </Text>
+            <Text data-testid="add-strategy-permission-coming-soon-description">
+              {t('permissionComingSoonDescription')}
+            </Text>
           </Flex>
         </Card>
       </Flex>

--- a/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
@@ -78,9 +78,13 @@ export function RefillGasTankModal({
         justify="space-between"
         align="center"
         mb={4}
+        data-testid="refill-gas-modal-header"
       >
         <Text textStyle="text-xl-regular">{t('refillTank')}</Text>
-        <CloseButton onClick={close} />
+        <CloseButton 
+          onClick={close}
+          data-testid="refill-gas-modal-close"
+        />
       </Flex>
 
       <Flex
@@ -95,6 +99,7 @@ export function RefillGasTankModal({
           }}
           borderColor="color-lilac-100"
           iconColor="color-lilac-100"
+          data-testid="refill-gas-direct-deposit-checkbox"
           sx={{
             '& .chakra-checkbox__control': {
               borderRadius: '0.25rem',
@@ -131,6 +136,7 @@ export function RefillGasTankModal({
             isInvalid={overDraft || paymasterGasTankErrors.deposit?.amount !== undefined}
             errorBorderColor="color-error-500"
             autoFocus
+            data-testid="refill-gas-amount-input"
           />
         </LabelWrapper>
 
@@ -143,6 +149,7 @@ export function RefillGasTankModal({
           <AssetSelector
             onlyNativeToken
             disabled
+            data-testid="refill-gas-asset-selector"
           />
           <Text
             textStyle="text-xs-medium"
@@ -170,11 +177,13 @@ export function RefillGasTankModal({
             setFieldValue('paymasterGasTank.deposit', undefined);
             close();
           }}
+          data-testid="refill-gas-cancel-button"
         >
           {t('cancel', { ns: 'common' })}
         </Button>
         <Button
           isDisabled={isSubmitDisabled}
+          data-testid="refill-gas-submit-button"
           onClick={() => {
             if (values.isDirectDeposit) {
               if (!walletClient) {

--- a/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/RefillGasTankModal.tsx
@@ -81,7 +81,7 @@ export function RefillGasTankModal({
         data-testid="refill-gas-modal-header"
       >
         <Text textStyle="text-xl-regular">{t('refillTank')}</Text>
-        <CloseButton 
+        <CloseButton
           onClick={close}
           data-testid="refill-gas-modal-close"
         />

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -52,8 +52,8 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
         data-testid="withdraw-gas-modal-header"
       >
         <Text textStyle="text-xl-regular">{t('withdrawGas')}</Text>
-        <CloseButton 
-          onClick={close} 
+        <CloseButton
+          onClick={close}
           data-testid="withdraw-gas-modal-close"
         />
       </Flex>

--- a/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
+++ b/src/components/ui/modals/GaslessVoting/WithdrawGasTankModal.tsx
@@ -45,13 +45,17 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
     paymasterGasTankErrors.withdraw?.recipientAddress !== undefined;
 
   return (
-    <Box>
+    <Box data-testid="withdraw-gas-modal">
       <Flex
         justify="space-between"
         align="center"
+        data-testid="withdraw-gas-modal-header"
       >
         <Text textStyle="text-xl-regular">{t('withdrawGas')}</Text>
-        <CloseButton onClick={close} />
+        <CloseButton 
+          onClick={close} 
+          data-testid="withdraw-gas-modal-close"
+        />
       </Flex>
 
       <Flex
@@ -85,6 +89,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
               placeholder="0"
               isInvalid={paymasterGasTankErrors.withdraw?.amount !== undefined}
               errorBorderColor="color-error-500"
+              data-testid="withdraw-gas-amount-input"
             />
           </LabelWrapper>
 
@@ -97,6 +102,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
             <AssetSelector
               onlyNativeToken
               disabled
+              data-testid="withdraw-gas-asset-selector"
             />
             <Text
               color={
@@ -128,6 +134,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
               setFieldValue('paymasterGasTank.withdraw.recipientAddress', e.target.value);
             }}
             isInvalid={paymasterGasTankErrors.withdraw?.recipientAddress !== undefined}
+            data-testid="withdraw-gas-recipient-input"
           />
         </LabelWrapper>
         <Button
@@ -137,6 +144,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
           onClick={() => {
             setFieldValue('paymasterGasTank.withdraw.recipientAddress', safe?.address);
           }}
+          data-testid="withdraw-gas-to-treasury-button"
         >
           {t('toDaoTreasury')}
         </Button>
@@ -153,6 +161,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
             setFieldValue('paymasterGasTank.withdraw', undefined);
             close();
           }}
+          data-testid="withdraw-gas-cancel-button"
         >
           {t('cancel', { ns: 'common' })}
         </Button>
@@ -163,6 +172,7 @@ export function WithdrawGasTankModal({ close }: { close: () => void }) {
             paymasterGasTankErrors.withdraw?.recipientAddress !== undefined ||
             isSubmitDisabled
           }
+          data-testid="withdraw-gas-submit-button"
         >
           {t('submitWithdrawAmount')}
         </Button>

--- a/src/components/ui/utils/AssetSelector.tsx
+++ b/src/components/ui/utils/AssetSelector.tsx
@@ -19,6 +19,7 @@ interface AssetSelectorProps {
    */
   lockedSelections?: string[];
   hideBalanceAndMergeTokens?: TokenBalance[];
+  'data-testid'?: string;
 }
 
 export const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
@@ -31,6 +32,7 @@ export function AssetSelector({
   canSelectMultiple = false,
   lockedSelections = [],
   hideBalanceAndMergeTokens,
+  'data-testid': testId,
 }: AssetSelectorProps) {
   const { t } = useTranslation(['roles', 'treasury', 'modals']);
 
@@ -90,6 +92,7 @@ export function AssetSelector({
     }>
       items={dropdownItems}
       selectedItem={selectedItems[0]}
+      data-testid={testId || 'asset-selector'}
       onSelect={item => {
         if (canSelectMultiple) {
           if (!selectedAddresses.includes(item.value)) {

--- a/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
+++ b/src/pages/dao/settings/general/SafeGeneralSettingsPage.tsx
@@ -214,6 +214,7 @@ export function SafeGeneralSettingsPage() {
 
                     setFieldValue('general.sponsoredVoting', newValue);
                   }}
+                  data-testid="general-gasless-voting-toggle"
                 />
               </>
             )}

--- a/src/pages/dao/settings/governance/GovernanceParams.tsx
+++ b/src/pages/dao/settings/governance/GovernanceParams.tsx
@@ -169,6 +169,7 @@ export function GovernanceParams() {
                     )
                   }
                   minWidth="100%"
+                  data-testid="governance-quorum-percentage"
                 />
                 <InputRightElement color="color-neutral-700">%</InputRightElement>
               </InputGroup>
@@ -218,6 +219,7 @@ export function GovernanceParams() {
                     ],
                   )
                 }
+                data-testid="governance-quorum-threshold"
               />
             </LabelComponent>
           </Flex>
@@ -261,6 +263,7 @@ export function GovernanceParams() {
                     ],
                   );
                 }}
+                data-testid="governance-voting-period"
               />
             </LabelComponent>
           </Flex>
@@ -304,6 +307,7 @@ export function GovernanceParams() {
                     ],
                   );
                 }}
+                data-testid="governance-timelock-period"
               />
             </LabelComponent>
           </Flex>
@@ -349,6 +353,7 @@ export function GovernanceParams() {
                     ],
                   )
                 }
+                data-testid="governance-execution-period"
               />
             </LabelComponent>
           </Flex>

--- a/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
+++ b/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
@@ -105,6 +105,7 @@ export function AddCreateProposalPermissionModal({
         onClick={closeModal}
         width={fullWidth ? 'full' : 'auto'}
         mt={6}
+        data-testid="permissions-save-button"
       >
         {t('save', { ns: 'common' })}
       </Button>
@@ -134,6 +135,7 @@ export function AddCreateProposalPermissionModal({
                 padding={0}
                 onClick={openConfirmDeleteStrategyModal}
                 color="color-error-400"
+                data-testid="permissions-delete-button-mobile"
               >
                 {t('delete', { ns: 'common' })}
               </Button>
@@ -166,9 +168,10 @@ export function AddCreateProposalPermissionModal({
                   aria-label={t('back', { ns: 'common' })}
                   onClick={closeModal}
                   icon={<ArrowLeft size={24} />}
+                  data-testid="permissions-back-button"
                 />
               ))}
-            <Text>{t('permissionCreateProposalsTitle')}</Text>
+            <Text data-testid="permissions-modal-title">{t('permissionCreateProposalsTitle')}</Text>
             {votingStrategyAddress && votingStrategyAddress !== zeroAddress ? (
               <IconButton
                 size="button-md"
@@ -177,6 +180,7 @@ export function AddCreateProposalPermissionModal({
                 icon={<Trash size={24} />}
                 aria-label={t('delete', { ns: 'common' })}
                 onClick={openConfirmDeleteStrategyModal}
+                data-testid="permissions-delete-button"
               />
             ) : (
               <IconButton
@@ -186,6 +190,7 @@ export function AddCreateProposalPermissionModal({
                 aria-label={t('close', { ns: 'common' })}
                 onClick={closeModal}
                 icon={<X size={24} />}
+                data-testid="permissions-close-button"
               />
             )}
           </Flex>

--- a/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
@@ -129,6 +129,7 @@ export function SafePermissionsSettingsPage() {
                 },
               },
             }}
+            data-testid="permissions-create-proposals-card"
           >
             <Flex justifyContent="space-between">
               <Flex
@@ -144,10 +145,11 @@ export function SafePermissionsSettingsPage() {
                   <Coins fontSize="1.5rem" />
                 </Box>
                 <Box>
-                  <Text>{t('permissionCreateProposalsTitle')}</Text>
+                  <Text data-testid="permissions-create-proposals-title">{t('permissionCreateProposalsTitle')}</Text>
                   <Text
                     textStyle="text-sm-medium"
                     color="color-neutral-300"
+                    data-testid="permissions-create-proposals-description"
                   >
                     {votesToken
                       ? t('permissionsErc20CreateProposalsDescription', {
@@ -171,6 +173,7 @@ export function SafePermissionsSettingsPage() {
                   opacity={0}
                   color="color-neutral-400"
                   border="none"
+                  data-testid="permissions-edit-button"
                 />
               )}
             </Flex>
@@ -187,6 +190,7 @@ export function SafePermissionsSettingsPage() {
               width="max-content"
               onClick={openAddPermissionModal}
               alignSelf="flex-end"
+              data-testid="permissions-add-permission-button"
             >
               {t('addPermission')}
             </Button>

--- a/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
+++ b/src/pages/dao/settings/permissions/SafePermissionsSettingsPage.tsx
@@ -145,7 +145,9 @@ export function SafePermissionsSettingsPage() {
                   <Coins fontSize="1.5rem" />
                 </Box>
                 <Box>
-                  <Text data-testid="permissions-create-proposals-title">{t('permissionCreateProposalsTitle')}</Text>
+                  <Text data-testid="permissions-create-proposals-title">
+                    {t('permissionCreateProposalsTitle')}
+                  </Text>
                   <Text
                     textStyle="text-sm-medium"
                     color="color-neutral-300"

--- a/src/pages/dao/settings/staking/SafeStakingSettingsPage.tsx
+++ b/src/pages/dao/settings/staking/SafeStakingSettingsPage.tsx
@@ -123,6 +123,7 @@ function StakingForm() {
               setFieldValue('staking.minimumStakingPeriod', undefined);
             }
           }}
+          data-testid="staking-minimum-period"
           hideSteppers
         />
       </LabelComponent>
@@ -180,6 +181,7 @@ function StakingForm() {
               setFieldValue('staking.newRewardTokens', undefined);
             }
           }}
+          data-testid="staking-reward-tokens-selector"
         />
       </LabelComponent>
     </>

--- a/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
+++ b/src/pages/dao/settings/token/SafeTokenSettingsPage.tsx
@@ -60,6 +60,7 @@ function WhitelistedAddress({
           isDisabled={true}
           textDecoration={willBeRemoved ? 'line-through' : 'none'}
           marginTop="-0.25rem"
+          data-testid={`token-whitelisted-address-${address.slice(0, 6)}`}
         />
       </GridItem>
       <GridItem
@@ -139,6 +140,7 @@ function NewWhitelistAddress({
                 tokenErrors?.addressesToWhitelist.findIndex(a => `token.${a.key}` === name) !== -1
               }
               marginTop="-0.25rem"
+              data-testid={`token-new-whitelist-address-${name.split('.').pop()}`}
             />
           )}
         </Field>


### PR DESCRIPTION
No pressure on this PR. If we don't like this, then we can trash it. Just doing this as a gut check.

The primary objective of these changes is to add test IDs to every relevant element in the Settings modal that exists today. The Settings modal was picked because I already added test IDs to the tabs, so it was easy to carry on that work and use the previous set of changes as reference. The Settings modal is also one of the worst offenders when it comes to not having good / stable locators to use for automation. It tends not to use IDs for inputs or stable class names that the automation can key off of.

Secondarily, this adds cross platform support for running the app locally so that the `npm run dev` script works for Windows as well as MacOS and Linux.