### PR TITLE
`[ENG-1349]` Can't edit in the modal of create proposal permission

### DIFF
--- a/src/components/SafeSettings/SettingsProposalPermissionForm.tsx
+++ b/src/components/SafeSettings/SettingsProposalPermissionForm.tsx
@@ -1,0 +1,121 @@
+import { Box, Button, Flex, Image, Text } from '@chakra-ui/react';
+import { Info } from '@phosphor-icons/react';
+import { useFormikContext } from 'formik';
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCurrentDAOKey } from '../../hooks/DAO/useCurrentDAOKey';
+import { useDAOStore } from '../../providers/App/AppProvider';
+import { AzoriusGovernance } from '../../types';
+import { BigIntInput } from '../ui/forms/BigIntInput';
+import LabelWrapper from '../ui/forms/LabelWrapper';
+import ModalTooltip from '../ui/modals/ModalTooltip';
+import { SafeSettingsEdits } from '../ui/modals/SafeSettingsModal';
+
+// New version of SettingsPermissionStrategyForm
+// Used by modal, read&write value with form context directly.
+export function SettingsProposalPermissionForm() {
+  const { t } = useTranslation('settings');
+  const tooltipContainerRef = useRef<HTMLDivElement>(null);
+  const { daoKey } = useCurrentDAOKey();
+  const { governance } = useDAOStore({ daoKey });
+  const azoriusGovernance = governance as AzoriusGovernance;
+  const { votesToken, erc721Tokens } = azoriusGovernance;
+
+  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const contractProposerThreshold = {
+    bigintValue: BigInt(azoriusGovernance.votingStrategy?.proposerThreshold?.value ?? 0),
+    value: azoriusGovernance.votingStrategy?.proposerThreshold?.formatted ?? '0',
+  };
+
+  if (!votesToken && !erc721Tokens) return null;
+
+  return (
+    <Flex
+      flexDirection="column"
+      gap={6}
+    >
+      <Flex
+        flexDirection="column"
+        gap={2}
+        align="flex-start"
+      >
+        <Flex
+          gap={1}
+          alignItems="center"
+          ref={tooltipContainerRef}
+        >
+          <Text textStyle="text-xl-regular">{t('asset')}</Text>
+          <Text color="color-lilac-100">*</Text>
+          <ModalTooltip
+            containerRef={tooltipContainerRef}
+            label={t('assetTooltip')}
+          >
+            <Box color="color-lilac-100">
+              <Info />
+            </Box>
+          </ModalTooltip>
+        </Flex>
+        <Button
+          variant="unstyled"
+          isDisabled
+          p={0}
+        >
+          <Flex
+            gap={3}
+            alignItems="center"
+            border="1px solid"
+            borderColor="color-neutral-900"
+            borderRadius="9999px"
+            w="fit-content"
+            className="payment-menu-asset"
+            p={2}
+          >
+            <Image
+              // @todo: Add asset logo
+              src="/images/coin-icon-default.svg"
+              boxSize="2.25rem"
+            />
+            <Text
+              textStyle="text-base-regular"
+              color="color-white"
+            >
+              {votesToken?.symbol || erc721Tokens?.map(token => token.symbol).join(', ')}
+            </Text>
+          </Flex>
+        </Button>
+      </Flex>
+      <LabelWrapper
+        label={t('permissionAmountLabel')}
+        labelColor="color-neutral-300"
+      >
+        <BigIntInput
+          onChange={val => {
+            const newBigIntValue = val.bigintValue;
+            const contractValue = contractProposerThreshold.bigintValue;
+            const formValue = values.permissions?.proposerThreshold?.bigintValue;
+
+            const shouldUpdate = newBigIntValue !== undefined && newBigIntValue !== contractValue;
+            const changesRecorded = formValue === newBigIntValue;
+            const hasEdits = formValue !== undefined;
+
+            if (!changesRecorded) {
+              if (shouldUpdate) {
+                setFieldValue('permissions.proposerThreshold', val);
+              } else {
+                if (hasEdits) {
+                  // The field is now same as the contract value, mark it as not edited
+                  setFieldValue('permissions', undefined);
+                }
+              }
+            }
+          }}
+          decimalPlaces={votesToken ? votesToken.decimals : 0}
+          value={
+            values.permissions?.proposerThreshold?.bigintValue ||
+            contractProposerThreshold?.bigintValue
+          }
+        />
+      </LabelWrapper>
+    </Flex>
+  );
+}

--- a/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
+++ b/src/pages/dao/settings/permissions/AddCreateProposalPermissionModal.tsx
@@ -1,13 +1,10 @@
 import { Button, Flex, IconButton, Show, Text } from '@chakra-ui/react';
 import { ArrowLeft, Trash, X } from '@phosphor-icons/react';
-import { useFormikContext } from 'formik';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, zeroAddress } from 'viem';
-import { SettingsPermissionsStrategyForm } from '../../../../components/SafeSettings/SettingsPermissionsStrategyForm';
+import { SettingsProposalPermissionForm } from '../../../../components/SafeSettings/SettingsProposalPermissionForm';
 import { Card } from '../../../../components/ui/cards/Card';
 import { ModalType } from '../../../../components/ui/modals/ModalProvider';
-import { SafeSettingsEdits } from '../../../../components/ui/modals/SafeSettingsModal';
 import { useDecentModal } from '../../../../components/ui/modals/useDecentModal';
 import NestedPageHeader from '../../../../components/ui/page/Header/NestedPageHeader';
 import Divider from '../../../../components/ui/utils/Divider';
@@ -15,7 +12,6 @@ import { DAO_ROUTES } from '../../../../constants/routes';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
 import { useDAOStore } from '../../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../../providers/NetworkConfig/useNetworkConfigStore';
-import { AzoriusGovernance, BigIntValuePair } from '../../../../types';
 
 // @todo Near-duplicate of SafePermissionsCreateProposal.tsx. Pending refactor and/or cleanup.
 // https://linear.app/decent-labs/issue/ENG-842/fix-permissions-settings-ux-flows
@@ -31,32 +27,12 @@ export function AddCreateProposalPermissionModal({
 
   const { daoKey } = useCurrentDAOKey();
   const {
-    governance,
     node: { safe },
   } = useDAOStore({ daoKey });
-  const azoriusGovernance = governance as AzoriusGovernance;
 
   const { open: openConfirmDeleteStrategyModal } = useDecentModal(
     ModalType.CONFIRM_DELETE_STRATEGY,
   );
-
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
-  const { permissions: permissionsEdits } = values;
-
-  const proposerThresholdFromGovernanceObject = (governanceObject: AzoriusGovernance) => {
-    return {
-      bigintValue: BigInt(governanceObject.votingStrategy?.proposerThreshold?.value ?? 0),
-      value: governanceObject.votingStrategy?.proposerThreshold?.formatted ?? '0',
-    };
-  };
-
-  const [existingProposerThreshold, setExistingProposerThreshold] = useState<BigIntValuePair>(
-    proposerThresholdFromGovernanceObject(azoriusGovernance),
-  );
-
-  useEffect(() => {
-    setExistingProposerThreshold(proposerThresholdFromGovernanceObject(azoriusGovernance));
-  }, [azoriusGovernance]);
 
   if (!safe) return null;
 
@@ -66,36 +42,7 @@ export function AddCreateProposalPermissionModal({
   );
 
   function FormContent() {
-    return (
-      <SettingsPermissionsStrategyForm
-        proposerThreshold={
-          permissionsEdits?.proposerThreshold !== undefined
-            ? permissionsEdits.proposerThreshold
-            : existingProposerThreshold
-        }
-        setProposerThreshold={val => {
-          let newProposerThresholdValue;
-
-          if (
-            permissionsEdits?.proposerThreshold === undefined &&
-            val.bigintValue !== undefined &&
-            val.bigintValue !== existingProposerThreshold.bigintValue
-          ) {
-            newProposerThresholdValue = val;
-          } else if (val.bigintValue !== existingProposerThreshold.bigintValue) {
-            newProposerThresholdValue = val;
-          } else {
-            newProposerThresholdValue = undefined;
-          }
-
-          if (newProposerThresholdValue === undefined) {
-            setFieldValue('permissions', undefined);
-          } else {
-            setFieldValue('permissions.proposerThreshold', newProposerThresholdValue);
-          }
-        }}
-      />
-    );
+    return <SettingsProposalPermissionForm />;
   }
 
   function SubmitButton({ fullWidth = false }: { fullWidth?: boolean }) {


### PR DESCRIPTION
### Summary

- Introduced a new component, `SettingsProposalPermissionForm`, by copying and modifying the existing `SettingsPermissionStrategyForm`.
- The new form interacts directly with Formik form values for both reading and writing, while the original component should only be used with simple state (not with Formik values).
- In the previous implementation, `proposerThreshold` was passed as a prop two levels deep, which caused the input to lose focus after each user input.
- The original component still has valid use cases, so a new dedicated component was created to address these specific issues.

### Root Cause & Takeaways

- The previous implementation of `setProposerThreshold` always called `setFieldValue`, even when the value hadn’t changed.
- The `BigIntInput` component triggers its `onChange` handler on mount via a `useEffect`.
- Combined, these behaviors caused a re-render loop: every change triggered another update, leading to infinite re-renders.
- As a result, users experienced issues such as being unable to edit fields, losing cursor/input focus, and browser hangs or crashes due to memory exhaustion.

### Related tickets

- [ENG-1345 App hangs when 'delete' option selected for permission in Settings](https://linear.app/decent-labs/issue/ENG-1345/app-hangs-when-delete-option-selected-for-permission-in-settings)
- [ENG-1349 Can't edit in the modal of create proposal permission](https://linear.app/decent-labs/issue/ENG-1349/cant-edit-in-the-modal-of-create-proposal-permission)
- [ENG-1357 Text input field for 'Create Proposal' permission "edit" form is non-functional](https://linear.app/decent-labs/issue/ENG-1357/text-input-field-for-create-proposal-permission-edit-form-is-non)