### PR TITLE
`[ENG-1372]` Fix Space bar propagation

### DIFF
--- a/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
+++ b/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
@@ -402,6 +402,7 @@ export function RevSplitTable({
   return (
     <Flex
       mx={'-1rem'}
+      mt={'-1rem'}
       direction="column"
     >
       <Divider my={4} />

--- a/src/components/ui/containers/AccordionDropdown.tsx
+++ b/src/components/ui/containers/AccordionDropdown.tsx
@@ -64,6 +64,7 @@ export function AccordionDropdown({
                 justifyContent="space-between"
               >
                 <AccordionButton
+                  as="div"
                   p={0}
                   textStyle="text-xl-regular"
                   color="color-lilac-100"

--- a/src/components/ui/forms/EditableInput.tsx
+++ b/src/components/ui/forms/EditableInput.tsx
@@ -6,17 +6,18 @@ import { useClickOutside } from '../../../hooks/useClickOutside';
 export function EditableInput(
   props: InputProps & { onEditCancel: () => void; onEditSave: () => void },
 ) {
+  const { onEditCancel, onEditSave, ...rest } = props;
   const [showInput, setShowInput] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   const cancelEdit = () => {
     setShowInput(false);
-    props.onEditCancel();
+    onEditCancel();
   };
 
   const saveEdit = () => {
     setShowInput(false);
-    props.onEditSave();
+    onEditSave();
   };
 
   useClickOutside(ref, () => {
@@ -30,6 +31,7 @@ export function EditableInput(
       <Flex
         alignItems="center"
         h="full"
+        py="0.5rem"
         gap="1rem"
         minW="10rem"
         px="1rem"
@@ -42,7 +44,7 @@ export function EditableInput(
       >
         <Text
           cursor="pointer"
-          textStyle="text-sm-regular"
+          textStyle="text-base-regular"
           color={props.isInvalid ? 'color-error-400' : 'color-layout-foreground'}
           whiteSpace="nowrap"
         >
@@ -68,11 +70,10 @@ export function EditableInput(
       justifyContent="space-between"
       w="full"
       h="full"
-      px="1rem"
       gap="1rem"
     >
       <Input
-        {...props}
+        {...rest}
         autoFocus
       />
       <IconButton


### PR DESCRIPTION
I attempted to fix this at the level of the editable input, unsuccessfully. The fix was to change the `AccordianButton` to `as={div}`. This seems to fix this behavior without changing the toggle behavior on click. 

Applied two other changes as well to adjust the placement of the input and the textStyle was incorrect.