### PR TITLE
`[ENG-1373]` Refactor; Settings Modal with readOnly status

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -137,5 +137,6 @@
   "calendarPlaceholder": "YYYY-MM-DD",
   "years": "Years",
   "addressInfoTooltip": "While DAO Name or ENS is displayed, the full wallet address will appear in the proposal.",
-  "stakingPeriodMoreThanZero": "Staking period must be more than zero"
+  "stakingPeriodMoreThanZero": "Staking period must be more than zero",
+  "close": "Close"
 }

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -113,7 +113,11 @@ function GaslessVotingToggleContent({
   isSettings,
   readOnly,
   displayNeedStakingLabel,
-}: GaslessVotingToggleProps & { isSettings?: boolean; readOnly?: boolean; displayNeedStakingLabel?: boolean }) {
+}: GaslessVotingToggleProps & {
+  isSettings?: boolean;
+  readOnly?: boolean;
+  displayNeedStakingLabel?: boolean;
+}) {
   const { t } = useTranslation('gaslessVoting');
   const { bundlerMinimumStake } = useNetworkConfigStore();
 

--- a/src/components/GaslessVoting/GaslessVotingToggle.tsx
+++ b/src/components/GaslessVoting/GaslessVotingToggle.tsx
@@ -8,7 +8,6 @@ import useFeatureFlag from '../../helpers/environmentFeatureFlags';
 import { usePaymasterDepositInfo } from '../../hooks/DAO/accountAbstraction/usePaymasterDepositInfo';
 import { useCurrentDAOKey } from '../../hooks/DAO/useCurrentDAOKey';
 import useNetworkPublicClient from '../../hooks/useNetworkPublicClient';
-import { useCanUserCreateProposal } from '../../hooks/utils/useCanUserSubmitProposal';
 import { createAccountSubstring } from '../../hooks/utils/useGetAccountName';
 import { useDAOStore } from '../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
@@ -112,11 +111,11 @@ function GaslessVotingToggleContent({
   isEnabled,
   onToggle,
   isSettings,
+  readOnly,
   displayNeedStakingLabel,
-}: GaslessVotingToggleProps & { isSettings?: boolean; displayNeedStakingLabel?: boolean }) {
+}: GaslessVotingToggleProps & { isSettings?: boolean; readOnly?: boolean; displayNeedStakingLabel?: boolean }) {
   const { t } = useTranslation('gaslessVoting');
   const { bundlerMinimumStake } = useNetworkConfigStore();
-  const { canUserCreateProposal } = useCanUserCreateProposal();
 
   const publicClient = useNetworkPublicClient();
   const nativeCurrency = publicClient.chain.nativeCurrency;
@@ -169,7 +168,7 @@ function GaslessVotingToggleContent({
         </Flex>
         <Switch
           size="md"
-          isDisabled={isSettings && !canUserCreateProposal}
+          isDisabled={isSettings && readOnly}
           isChecked={isEnabled}
           onChange={() => onToggle()}
           variant="secondary"
@@ -199,7 +198,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
   const gaslessFeatureEnabled = useFeatureFlag('flag_gasless_voting');
   const gaslessStakingEnabled = gaslessFeatureEnabled && bundlerMinimumStake !== undefined;
 
-  const { values, setFieldValue } = settingsModalFormikContext;
+  const { values, setFieldValue, status: { readOnly } = {} } = settingsModalFormikContext;
 
   const paymasterGasTankEdits = values?.paymasterGasTank;
   useEffect(() => {
@@ -248,6 +247,7 @@ export function GaslessVotingToggleDAOSettings(props: GaslessVotingToggleProps) 
       <GaslessVotingToggleContent
         {...props}
         isSettings
+        readOnly={readOnly}
         displayNeedStakingLabel={gaslessStakingEnabled && stakedAmount < minStakeAmount}
       />
 

--- a/src/components/SafeSettings/RevenueShare/RevenueSharingContent.tsx
+++ b/src/components/SafeSettings/RevenueShare/RevenueSharingContent.tsx
@@ -15,7 +15,7 @@ import { RevSplitWalletAccordion } from './RevenueSplitWallets';
 import { mergeSplitWalletFormData } from './revenueShareFormHandlers';
 
 function RevenueShareHeader() {
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const { t } = useTranslation('revenueSharing');
 
   return (
@@ -37,6 +37,7 @@ function RevenueShareHeader() {
         size="sm"
         ml="auto"
         leftIcon={<Icon as={Plus} />}
+        isDisabled={readOnly}
         onClick={() => {
           const formWallets = [...(values.revenueSharing?.new || [])];
 

--- a/src/components/SafeSettings/RevenueShare/RevenueSharingContent.tsx
+++ b/src/components/SafeSettings/RevenueShare/RevenueSharingContent.tsx
@@ -15,7 +15,11 @@ import { RevSplitWalletAccordion } from './RevenueSplitWallets';
 import { mergeSplitWalletFormData } from './revenueShareFormHandlers';
 
 function RevenueShareHeader() {
-  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    values,
+    setFieldValue,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const { t } = useTranslation('revenueSharing');
 
   return (

--- a/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
+++ b/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
@@ -81,6 +81,7 @@ function WalletName({
   wallet: RevenueSharingWalletFormValues;
   walletFormType: RevenueSharingWalletFormType;
 }) {
+  const { status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   return (
     <Grid
       templateColumns="auto 1fr"
@@ -92,6 +93,7 @@ function WalletName({
         {({ field, form }: FieldProps<string, any>) => (
           <EditableInput
             value={field.value || wallet.name}
+            isReadOnly={readOnly}
             onClick={e => {
               e.stopPropagation();
             }}
@@ -151,6 +153,7 @@ export function RevSplitRow({
   onRemoveSplit?: () => void;
 }) {
   const { t } = useTranslation('revenueSharing');
+  const { status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
 
   return (
     <>
@@ -162,7 +165,7 @@ export function RevSplitRow({
               return (
                 <AddressInputInfo
                   isInvalid={!!splitFormError?.address}
-                  isReadOnly={isReadOnlyAddress}
+                  isReadOnly={isReadOnlyAddress || readOnly}
                   staticDisplayValue={isStakingContract ? t('stakingRecipientDisplay') : undefined}
                   variant="tableStyle"
                   value={fieldValue}
@@ -194,6 +197,7 @@ export function RevSplitRow({
                   variant="tableStyle"
                   precision={0}
                   isInvalid={!!splitFormError?.percentage}
+                  isReadOnly={readOnly}
                   value={fieldValue}
                   min={0}
                   max={100}
@@ -221,7 +225,7 @@ export function RevSplitRow({
           >
             <IconButton
               aria-label={t('removeSplitButtonLabel')}
-              hidden={!onRemoveSplit}
+              hidden={!onRemoveSplit || readOnly}
               icon={<Trash />}
               color="color-error-400"
               borderColor="color-error-400"
@@ -251,7 +255,7 @@ export function RevSplitTable({
   walletIndex: number;
   walletFormType: RevenueSharingWalletFormType;
 }) {
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const { t } = useTranslation('revenueSharing');
   const { daoKey } = useCurrentDAOKey();
   const {
@@ -469,6 +473,7 @@ export function RevSplitTable({
         size="sm"
         ml="auto"
         leftIcon={<Icon as={Plus} />}
+        isDisabled={readOnly}
         onClick={() => {
           const formWalletSplits = [...(wallet.splits || [])];
 

--- a/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
+++ b/src/components/SafeSettings/RevenueShare/RevenueSplitWallets.tsx
@@ -255,7 +255,11 @@ export function RevSplitTable({
   walletIndex: number;
   walletFormType: RevenueSharingWalletFormType;
 }) {
-  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    values,
+    setFieldValue,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const { t } = useTranslation('revenueSharing');
   const { daoKey } = useCurrentDAOKey();
   const {

--- a/src/components/SafeSettings/Signers/SignersContainer.tsx
+++ b/src/components/SafeSettings/Signers/SignersContainer.tsx
@@ -148,7 +148,7 @@ export function SignersContainer() {
 
   const { t } = useTranslation(['common', 'breadcrumbs', 'daoEdit']);
 
-  const { setFieldValue, values, errors } = useFormikContext<SafeSettingsEdits>();
+  const { setFieldValue, values, errors, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
 
   const multisigEditFormikErrors = (errors as SafeSettingsFormikErrors | undefined)?.multisig;
 
@@ -280,7 +280,7 @@ export function SignersContainer() {
                   }
                 : null
             }
-            canRemove={canRemoveMoreSigners}
+            canRemove={canRemoveMoreSigners && !readOnly}
           />
         ))}
         {values.multisig?.newSigners?.map(signer => (
@@ -293,11 +293,11 @@ export function SignersContainer() {
                 values.multisig?.newSigners?.filter(s => s.key !== signer.key),
               );
             }}
-            canRemove={canRemoveMoreSigners}
+            canRemove={canRemoveMoreSigners && !readOnly}
           />
         ))}
 
-        {userIsSigner && (
+        {!readOnly && (
           <Flex
             gap="0.5rem"
             justifyContent="flex-end"
@@ -357,6 +357,7 @@ export function SignersContainer() {
           {/* stepper */}
           <Flex w="200px">
             <NumberStepperInput
+              disabled={readOnly}
               onChange={value => {
                 let updatedValue;
                 if (value !== `${safe?.threshold}`) {

--- a/src/components/SafeSettings/Signers/SignersContainer.tsx
+++ b/src/components/SafeSettings/Signers/SignersContainer.tsx
@@ -148,7 +148,12 @@ export function SignersContainer() {
 
   const { t } = useTranslation(['common', 'breadcrumbs', 'daoEdit']);
 
-  const { setFieldValue, values, errors, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    setFieldValue,
+    values,
+    errors,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
 
   const multisigEditFormikErrors = (errors as SafeSettingsFormikErrors | undefined)?.multisig;
 

--- a/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
@@ -3,7 +3,6 @@ import { useFormikContext } from 'formik';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
-import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
 import { createAccountSubstring } from '../../../../hooks/utils/useGetAccountName';
 import { useDAOStore } from '../../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../../providers/NetworkConfig/useNetworkConfigStore';
@@ -17,7 +16,7 @@ import { SettingsContentBox } from '../../SettingsContentBox';
 
 export function SafeGeneralSettingTab() {
   const { t } = useTranslation('settings');
-  const { setFieldValue, values: formValues, errors } = useFormikContext<SafeSettingsEdits>();
+  const { setFieldValue, values: formValues, errors, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const generalEditFormikErrors = (errors as SafeSettingsFormikErrors | undefined)?.general;
 
   const [existingDaoName, setExistingDaoName] = useState('');
@@ -36,7 +35,6 @@ export function SafeGeneralSettingTab() {
     setExistingIsGaslessVotingEnabledToggled(gaslessVotingEnabled);
   }, [gaslessVotingEnabled]);
 
-  const { canUserCreateProposal } = useCanUserCreateProposal();
   const { bundlerMinimumStake } = useNetworkConfigStore();
   const accountAbstractionSupported = bundlerMinimumStake !== undefined;
 
@@ -115,8 +113,8 @@ export function SafeGeneralSettingTab() {
                       e.target.value === existingDaoName ? undefined : e.target.value.trim();
                     setFieldValue('general.name', newValue);
                   }}
-                  disabled={!canUserCreateProposal}
                   value={formValues.general?.name ?? existingDaoName}
+                  disabled={readOnly}
                   placeholder={formValues.general?.name === undefined ? 'Amazing DAO' : ''}
                   testId="daoSettings.name"
                   isInvalid={!!generalEditFormikErrors?.name}
@@ -153,7 +151,7 @@ export function SafeGeneralSettingTab() {
                       ? existingSnapshotENS
                       : formValues.general?.snapshot
                   }
-                  disabled={!canUserCreateProposal}
+                  disabled={readOnly}
                   placeholder="example.eth"
                   testId="daoSettings.snapshotENS"
                   inputContainerProps={{

--- a/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
@@ -16,7 +16,12 @@ import { SettingsContentBox } from '../../SettingsContentBox';
 
 export function SafeGeneralSettingTab() {
   const { t } = useTranslation('settings');
-  const { setFieldValue, values: formValues, errors, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    setFieldValue,
+    values: formValues,
+    errors,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const generalEditFormikErrors = (errors as SafeSettingsFormikErrors | undefined)?.general;
 
   const [existingDaoName, setExistingDaoName] = useState('');

--- a/src/components/SafeSettings/TabContents/governance/GovernanceParams.tsx
+++ b/src/components/SafeSettings/TabContents/governance/GovernanceParams.tsx
@@ -27,7 +27,7 @@ export function GovernanceParams() {
     node: { safe },
   } = useDAOStore({ daoKey });
 
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const publicClient = useNetworkPublicClient();
   const { getTimeDuration } = useTimeHelpers();
 
@@ -144,6 +144,7 @@ export function GovernanceParams() {
             >
               <InputGroup>
                 <BigIntInput
+                  isDisabled={readOnly}
                   value={
                     values.azorius?.quorumPercentage !== undefined
                       ? values.azorius?.quorumPercentage
@@ -193,6 +194,7 @@ export function GovernanceParams() {
               gridContainerProps={inputGridContainerProps}
             >
               <BigIntInput
+                isDisabled={readOnly}
                 value={
                   values.azorius?.quorumThreshold !== undefined
                     ? values.azorius?.quorumThreshold
@@ -239,6 +241,7 @@ export function GovernanceParams() {
               gridContainerProps={inputGridContainerProps}
             >
               <DurationUnitStepperInput
+                isDisabled={readOnly}
                 secondsValue={Number(
                   values.azorius?.votingPeriod !== undefined
                     ? values.azorius?.votingPeriod
@@ -282,6 +285,7 @@ export function GovernanceParams() {
               gridContainerProps={inputGridContainerProps}
             >
               <DurationUnitStepperInput
+                isDisabled={readOnly}
                 secondsValue={Number(
                   values.azorius?.timelockPeriod !== undefined
                     ? values.azorius?.timelockPeriod
@@ -325,6 +329,7 @@ export function GovernanceParams() {
               gridContainerProps={inputGridContainerProps}
             >
               <DurationUnitStepperInput
+                isDisabled={readOnly}
                 secondsValue={Number(
                   values.azorius?.executionPeriod !== undefined
                     ? values.azorius?.executionPeriod

--- a/src/components/SafeSettings/TabContents/governance/GovernanceParams.tsx
+++ b/src/components/SafeSettings/TabContents/governance/GovernanceParams.tsx
@@ -27,7 +27,11 @@ export function GovernanceParams() {
     node: { safe },
   } = useDAOStore({ daoKey });
 
-  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    values,
+    setFieldValue,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const publicClient = useNetworkPublicClient();
   const { getTimeDuration } = useTimeHelpers();
 

--- a/src/components/SafeSettings/TabContents/permissions/SafePermissionsSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/permissions/SafePermissionsSettingTab.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import PencilWithLineIcon from '../../../../assets/theme/custom/icons/PencilWithLineIcon';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useCurrentDAOKey } from '../../../../hooks/DAO/useCurrentDAOKey';
-import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
 import { useDAOStore } from '../../../../providers/App/AppProvider';
 import { AzoriusGovernance } from '../../../../types';
 import NoDataCard from '../../../ui/containers/NoDataCard';
@@ -25,11 +24,10 @@ export function SafePermissionsSettingTab() {
     node: { safe },
   } = useDAOStore({ daoKey });
 
-  const { canUserCreateProposal } = useCanUserCreateProposal();
   const azoriusGovernance = governance as AzoriusGovernance;
   const { votesToken, erc721Tokens } = azoriusGovernance;
 
-  const { values } = useFormikContext<SafeSettingsEdits>();
+  const { values, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
 
   const { open: openAddCreateProposalPermissionModal } = useDecentModal(
     ModalType.ADD_CREATE_PROPOSAL_PERMISSION,
@@ -145,7 +143,7 @@ export function SafePermissionsSettingTab() {
                     </Text>
                   </Box>
                 </Flex>
-                {canUserCreateProposal && (
+                {!readOnly && (
                   <IconButton
                     variant="secondary"
                     size="icon-md"
@@ -159,7 +157,7 @@ export function SafePermissionsSettingTab() {
               </Flex>
             </Box>
           )}
-          {canUserCreateProposal && (
+          {!readOnly && (
             <Flex flexDir="column">
               <Divider />
               <Button

--- a/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
@@ -43,7 +43,7 @@ function StakingForm() {
   const {
     stablecoins: { usdc },
   } = useNetworkConfigStore();
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const { errors } = useFormikContext<SafeSettingsEdits>();
   const stakingErrors = (errors as SafeSettingsFormikErrors | undefined)?.staking;
 
@@ -104,6 +104,7 @@ function StakingForm() {
         errorMessage={stakingErrors?.minimumStakingPeriod}
       >
         <DurationUnitStepperInput
+          isDisabled={readOnly}
           secondsValue={minPeriodValue}
           onSecondsValueChange={val => {
             if (val === undefined) {
@@ -162,6 +163,7 @@ function StakingForm() {
         <AssetSelector
           includeNativeToken
           canSelectMultiple
+          disabled={readOnly}
           lockedSelections={rewardsTokens}
           hideBalanceAndMergeTokens={mergeTokens}
           onSelect={addresses => {
@@ -192,7 +194,7 @@ export function SafeStakingSettingTab() {
     governance: { stakedToken },
   } = useDAOStore({ daoKey });
 
-  const { values, setFieldValue } = useFormikContext<SafeSettingsEdits>();
+  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
   const deploying = values.staking?.deploying || false;
   const showForm = stakedToken?.address !== undefined || deploying;
 
@@ -210,6 +212,7 @@ export function SafeStakingSettingTab() {
         </Text>
         <Button
           mt={1.5}
+          isDisabled={readOnly}
           width="fit-content"
           onClick={() => setFieldValue('staking.deploying', true)}
         >

--- a/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
@@ -43,7 +43,11 @@ function StakingForm() {
   const {
     stablecoins: { usdc },
   } = useNetworkConfigStore();
-  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    values,
+    setFieldValue,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const { errors } = useFormikContext<SafeSettingsEdits>();
   const stakingErrors = (errors as SafeSettingsFormikErrors | undefined)?.staking;
 
@@ -194,7 +198,11 @@ export function SafeStakingSettingTab() {
     governance: { stakedToken },
   } = useDAOStore({ daoKey });
 
-  const { values, setFieldValue, status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
+  const {
+    values,
+    setFieldValue,
+    status: { readOnly } = {},
+  } = useFormikContext<SafeSettingsEdits>();
   const deploying = values.staking?.deploying || false;
   const showForm = stakedToken?.address !== undefined || deploying;
 

--- a/src/components/SafeSettings/TabContents/token/SafeTokenSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/token/SafeTokenSettingTab.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Text } from '@chakra-ui/react';
+import { useFormikContext } from 'formik';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -9,6 +10,7 @@ import { useNetworkConfigStore } from '../../../../providers/NetworkConfig/useNe
 import { formatCoin } from '../../../../utils';
 import { DisplayAddress } from '../../../ui/links/DisplayAddress';
 import { ModalContext } from '../../../ui/modals/ModalProvider';
+import { SafeSettingsEdits } from '../../../ui/modals/SafeSettingsModal';
 import Divider from '../../../ui/utils/Divider';
 import { SettingsContentBox } from '../../SettingsContentBox';
 
@@ -23,6 +25,7 @@ export function SafeTokenSettingTab() {
   } = useDAOStore({ daoKey });
 
   const { closeAllModals } = useContext(ModalContext);
+  const { status: { readOnly } = {} } = useFormikContext<SafeSettingsEdits>();
 
   return (
     <>
@@ -126,6 +129,7 @@ export function SafeTokenSettingTab() {
               </Flex>
 
               <Button
+                isDisabled={readOnly}
                 onClick={() => {
                   if (!safe) return;
                   closeAllModals();

--- a/src/components/ui/forms/AddressInputInfo.tsx
+++ b/src/components/ui/forms/AddressInputInfo.tsx
@@ -86,7 +86,7 @@ export function AddressInputInfo(props: InputProps & { staticDisplayValue?: stri
         bg={props.isReadOnly ? 'transparent' : props.isInvalid ? 'color-error-950' : 'transparent'}
       >
         <Text
-          cursor={props.isReadOnly ? "default" : "pointer"}
+          cursor={props.isReadOnly ? 'default' : 'pointer'}
           textStyle="text-sm-regular"
           color={props.isInvalid ? 'color-error-400' : 'color-layout-foreground'}
           overflow="hidden"

--- a/src/components/ui/forms/AddressInputInfo.tsx
+++ b/src/components/ui/forms/AddressInputInfo.tsx
@@ -69,7 +69,9 @@ export function AddressInputInfo(props: InputProps & { staticDisplayValue?: stri
         h="full"
         px="1rem"
         onClick={() => {
-          setShowInput(true);
+          if (!props.isReadOnly) {
+            setShowInput(true);
+          }
         }}
         onBlur={() => {
           setShowInput(false);
@@ -84,7 +86,7 @@ export function AddressInputInfo(props: InputProps & { staticDisplayValue?: stri
         bg={props.isReadOnly ? 'transparent' : props.isInvalid ? 'color-error-950' : 'transparent'}
       >
         <Text
-          cursor="pointer"
+          cursor={props.isReadOnly ? "default" : "pointer"}
           textStyle="text-sm-regular"
           color={props.isInvalid ? 'color-error-400' : 'color-layout-foreground'}
           overflow="hidden"

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -48,6 +48,7 @@ export default function DurationUnitStepperInput({
   color = 'color-white',
   hideSteppers = false,
   placeholder = '0',
+  isDisabled = false,
 }: {
   secondsValue: number | undefined;
   onSecondsValueChange: (val: number | undefined) => void;
@@ -55,6 +56,7 @@ export default function DurationUnitStepperInput({
   color?: string;
   hideSteppers?: boolean;
   placeholder?: string;
+  isDisabled?: boolean;
 }) {
   const { t } = useTranslation('common');
 
@@ -96,6 +98,7 @@ export default function DurationUnitStepperInput({
       onChange={val => onSecondsValueChange(Number(val) * selectedUnit.unit)}
       min={minSeconds / selectedUnit.unit}
       focusInputOnChange
+      isDisabled={isDisabled}
     >
       <HStack gap="0.25rem">
         {!hideSteppers && <NumberDecrementStepper>{stepperButton('dec')}</NumberDecrementStepper>}
@@ -112,6 +115,7 @@ export default function DurationUnitStepperInput({
             borderLeftColor="white-alpha-16"
           >
             <Select
+              isDisabled={isDisabled}
               bgColor="color-black"
               borderColor="color-neutral-900"
               rounded="lg"
@@ -135,7 +139,7 @@ export default function DurationUnitStepperInput({
                 }
               }}
               value={selectedUnit.label}
-            >
+            > 
               {units.map((u, i) => (
                 <option
                   key={i}

--- a/src/components/ui/forms/DurationUnitStepperInput.tsx
+++ b/src/components/ui/forms/DurationUnitStepperInput.tsx
@@ -139,7 +139,7 @@ export default function DurationUnitStepperInput({
                 }
               }}
               value={selectedUnit.label}
-            > 
+            >
               {units.map((u, i) => (
                 <option
                   key={i}

--- a/src/components/ui/forms/EditableInput.tsx
+++ b/src/components/ui/forms/EditableInput.tsx
@@ -45,7 +45,7 @@ export function EditableInput(
         bg={props.isInvalid ? 'color-error-950' : 'transparent'}
       >
         <Text
-          cursor={props.isReadOnly ? "default" : "pointer"}
+          cursor={props.isReadOnly ? 'default' : 'pointer'}
           textStyle="text-base-regular"
           color={props.isInvalid ? 'color-error-400' : 'color-layout-foreground'}
           whiteSpace="nowrap"

--- a/src/components/ui/forms/EditableInput.tsx
+++ b/src/components/ui/forms/EditableInput.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import { useClickOutside } from '../../../hooks/useClickOutside';
 
 export function EditableInput(
-  props: InputProps & { onEditCancel: () => void; onEditSave: () => void },
+  props: InputProps & { onEditCancel: () => void; onEditSave: () => void; isReadOnly?: boolean },
 ) {
   const { onEditCancel, onEditSave, ...rest } = props;
   const [showInput, setShowInput] = useState(false);
@@ -37,29 +37,33 @@ export function EditableInput(
         px="1rem"
         onClick={e => {
           e.stopPropagation();
-          setShowInput(true);
+          if (!props.isReadOnly) {
+            setShowInput(true);
+          }
         }}
         borderRadius="0.75rem"
         bg={props.isInvalid ? 'color-error-950' : 'transparent'}
       >
         <Text
-          cursor="pointer"
+          cursor={props.isReadOnly ? "default" : "pointer"}
           textStyle="text-base-regular"
           color={props.isInvalid ? 'color-error-400' : 'color-layout-foreground'}
           whiteSpace="nowrap"
         >
           {props.value}
         </Text>
-        <IconButton
-          size="icon-sm"
-          icon={<PencilSimple />}
-          variant="ghostV1"
-          onClick={e => {
-            e.stopPropagation();
-            setShowInput(true);
-          }}
-          aria-label="Edit"
-        />
+        {!props.isReadOnly && (
+          <IconButton
+            size="icon-sm"
+            icon={<PencilSimple />}
+            variant="ghostV1"
+            onClick={e => {
+              e.stopPropagation();
+              setShowInput(true);
+            }}
+            aria-label="Edit"
+          />
+        )}
       </Flex>
     );
   }

--- a/src/components/ui/forms/InputComponent.tsx
+++ b/src/components/ui/forms/InputComponent.tsx
@@ -36,6 +36,7 @@ interface InputProps extends Omit<BaseProps, 'children'> {
   placeholder?: string;
   testId: string;
   isInvalid?: boolean;
+  isReadOnly?: boolean;
 }
 
 interface TextareaProps extends Omit<BaseProps, 'children'> {

--- a/src/components/ui/forms/NumberInputPercentage.tsx
+++ b/src/components/ui/forms/NumberInputPercentage.tsx
@@ -1,7 +1,7 @@
 import { NumberInputProps, NumberInput, NumberInputField, Text, Flex } from '@chakra-ui/react';
 import { useState } from 'react';
 import { formatPercentageV1 } from '../../../utils';
-export function NumberInputPercentage(props: NumberInputProps) {
+export function NumberInputPercentage(props: NumberInputProps & { isReadOnly?: boolean }) {
   const [showInput, setShowInput] = useState(false);
   const invalid = props.isInvalid;
   const invalidState = {
@@ -21,10 +21,12 @@ export function NumberInputPercentage(props: NumberInputProps) {
         px="1rem"
         alignItems="center"
         _hover={{
-          bg: 'color-alpha-white-950',
+          bg: props.isReadOnly ? 'transparent' : 'color-alpha-white-950',
         }}
         onClick={() => {
-          setShowInput(true);
+          if (!props.isReadOnly) {
+            setShowInput(true);
+          }
         }}
         onBlur={() => {
           setShowInput(false);
@@ -32,7 +34,7 @@ export function NumberInputPercentage(props: NumberInputProps) {
         {...(invalid ? invalidState : {})}
       >
         <Text
-          cursor="pointer"
+          cursor={props.isReadOnly ? "default" : "pointer"}
           w="full"
           position="relative"
           sx={{

--- a/src/components/ui/forms/NumberInputPercentage.tsx
+++ b/src/components/ui/forms/NumberInputPercentage.tsx
@@ -34,7 +34,7 @@ export function NumberInputPercentage(props: NumberInputProps & { isReadOnly?: b
         {...(invalid ? invalidState : {})}
       >
         <Text
-          cursor={props.isReadOnly ? "default" : "pointer"}
+          cursor={props.isReadOnly ? 'default' : 'pointer'}
           w="full"
           position="relative"
           sx={{

--- a/src/components/ui/modals/FormReadOnlyController.tsx
+++ b/src/components/ui/modals/FormReadOnlyController.tsx
@@ -1,0 +1,23 @@
+import { useFormikContext } from 'formik';
+import { useEffect } from 'react';
+
+interface FormReadOnlyControllerProps {
+  isReadOnly: boolean;
+}
+
+/**
+ * Component that manages form read-only state via Formik's status property.
+ * Must be used inside a Formik form context.
+ */
+export function FormReadOnlyController({ isReadOnly }: FormReadOnlyControllerProps) {
+  const { setStatus, status } = useFormikContext();
+
+  useEffect(() => {
+    const currentReadOnly = status?.readOnly ?? false;
+    if (currentReadOnly !== isReadOnly) {
+      setStatus({ ...status, readOnly: isReadOnly });
+    }
+  }, [isReadOnly, setStatus, status]);
+
+  return null;
+}

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -178,7 +178,7 @@ export function SafeSettingsModal({
           px="2rem"
           onClick={closeModal}
         >
-          {t('discardChanges', { ns: 'common' })}
+          {t(canUserCreateProposal ? 'discardChanges' : 'close', { ns: 'common' })}
         </Button>
         {canUserCreateProposal && (
           <Button

--- a/src/components/ui/modals/SafeSettingsModal.tsx
+++ b/src/components/ui/modals/SafeSettingsModal.tsx
@@ -34,6 +34,7 @@ import {
   validateFormHasErrors,
 } from '../../SafeSettings/handlers';
 import Divider from '../utils/Divider';
+import { FormReadOnlyController } from './FormReadOnlyController';
 import { ModalProvider } from './ModalProvider';
 
 export type SafeSettingsEdits = {
@@ -369,6 +370,7 @@ export function SafeSettingsModal({
   return (
     <Formik<SafeSettingsEdits>
       initialValues={{}}
+      initialStatus={{ readOnly: !canUserCreateProposal }}
       validate={values => {
         return validateSafeSettingsForm(values, {
           validateAddress,
@@ -390,6 +392,7 @@ export function SafeSettingsModal({
       }}
     >
       <Form>
+        <FormReadOnlyController isReadOnly={!canUserCreateProposal} />
         <ModalProvider
           baseZIndex={2000}
           closeBaseModal={closeModal}

--- a/src/hooks/utils/useCanUserSubmitProposal.ts
+++ b/src/hooks/utils/useCanUserSubmitProposal.ts
@@ -129,7 +129,8 @@ export function useCanUserCreateProposal() {
       }
     };
     loadCanUserCreateProposal();
-  }, [getCanUserCreateProposal, canUserCreateProposal, addressPrefix, publicClient.chain.id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getCanUserCreateProposal, addressPrefix, publicClient.chain.id]);
 
   return { canUserCreateProposal, getCanUserCreateProposal };
 }


### PR DESCRIPTION
two improvements:
- Removes redundent `useCanUserSubmitProposal` hook mounts, each mount was making several requests
- setting form now uses `status` property to put form in read-only (disabled) state
- update button from 'Discard' to 'Close' when readonly

## Screenshots
<img width="1280" height="900" alt="localhost_3000_home_dao=sep%3A0x49D1e062c3276a99067A6A186e75AEbf8E98243c page=1 size=10(Desktop) (7)" src="https://github.com/user-attachments/assets/b2075a17-c580-453c-b522-18adeba5250e" />
<img width="1280" height="900" alt="localhost_3000_home_dao=sep%3A0x49D1e062c3276a99067A6A186e75AEbf8E98243c page=1 size=10(Desktop) (6)" src="https://github.com/user-attachments/assets/e05ffcb9-722e-4e4e-9578-06ea7f461b36" />
<img width="1280" height="900" alt="localhost_3000_home_dao=sep%3A0x49D1e062c3276a99067A6A186e75AEbf8E98243c page=1 size=10(Desktop) (5)" src="https://github.com/user-attachments/assets/96ef3fd6-4fdb-4c89-9ee4-7cee01909fa4" />
<img width="1280" height="900" alt="localhost_3000_home_dao=sep%3A0x49D1e062c3276a99067A6A186e75AEbf8E98243c page=1 size=10(Desktop) (4)" src="https://github.com/user-attachments/assets/d9dbd816-9a8f-491e-a81f-a73d282402b2" />
<img width="1280" height="900" alt="localhost_3000_home_dao=sep%3A0x49D1e062c3276a99067A6A186e75AEbf8E98243c page=1 size=10(Desktop) (3)" src="https://github.com/user-attachments/assets/01bb7fd1-2cca-4184-9ec5-6f1fc61b36a0" />
