### PR TITLE
`[ENG-1361]` fix AssetSelector click area by moving it out of LabelComponent wrapper

### DIFF
--- a/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/staking/SafeStakingSettingTab.tsx
@@ -177,27 +177,28 @@ function StakingForm() {
         }}
         helper={t('rewardTokensHelper')}
       >
-        <AssetSelector
-          includeNativeToken
-          canSelectMultiple
-          disabled={readOnly}
-          lockedSelections={rewardsTokens}
-          hideBalanceAndMergeTokens={mergeTokens}
-          onSelect={addresses => {
-            const rewardTokensToBeAdded = addresses.filter(
-              a => !rewardsTokens?.includes(a as Address),
-            );
-            if (rewardTokensToBeAdded.length > 0) {
-              setFieldValue(
-                'staking.newRewardTokens',
-                addresses.filter(a => !rewardsTokens?.includes(a as Address)),
-              );
-            } else {
-              setFieldValue('staking.newRewardTokens', undefined);
-            }
-          }}
-        />
+        <></>
       </LabelComponent>
+      <AssetSelector
+        includeNativeToken
+        canSelectMultiple
+        disabled={readOnly}
+        lockedSelections={rewardsTokens}
+        hideBalanceAndMergeTokens={mergeTokens}
+        onSelect={addresses => {
+          const rewardTokensToBeAdded = addresses.filter(
+            a => !rewardsTokens?.includes(a as Address),
+          );
+          if (rewardTokensToBeAdded.length > 0) {
+            setFieldValue(
+              'staking.newRewardTokens',
+              addresses.filter(a => !rewardsTokens?.includes(a as Address)),
+            );
+          } else {
+            setFieldValue('staking.newRewardTokens', undefined);
+          }
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
### Summary

To avoid click area too big for AssetSelector inside Staking setting tab, move it out of label wrapper.