### PR TITLE
`[ENG-1401]` use primitive values as dependencies instead of object, which is always same reference

### DIFF
--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -40,7 +40,7 @@ export function SafeProposalWithActionsCreatePage() {
 
   const defaultProposalValues = useMemo(
     () =>
-      proposalMetadata
+      proposalMetadata?.title || proposalMetadata?.description || proposalMetadata?.documentationUrl
         ? {
             ...DEFAULT_PROPOSAL,
             proposalMetadata: {
@@ -57,7 +57,12 @@ export function SafeProposalWithActionsCreatePage() {
               nonce: safe?.nextNonce,
             },
           },
-    [proposalMetadata, safe?.nextNonce],
+    [
+      proposalMetadata?.title,
+      proposalMetadata?.description,
+      proposalMetadata?.documentationUrl,
+      safe?.nextNonce,
+    ],
   );
 
   const { addressPrefix } = useNetworkConfigStore();


### PR DESCRIPTION
### Summary

`proposalMetadata` returned from Zustand store is always same reference, which makes `defaultProposalValues` never synced with new metadata which includes title and body. So every time actions are added or removed, metadata get "RESET" to initial empty value.