### PR TITLE
`[ENG-1134]` Only trim DAO name input on blur, so user can input name with spaces normally

### DIFF
--- a/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
@@ -115,9 +115,10 @@ export function SafeGeneralSettingTab() {
                   isRequired={false}
                   onChange={e => {
                     const newValue =
-                      e.target.value === existingDaoName ? undefined : e.target.value.trim();
+                      e.target.value === existingDaoName ? undefined : e.target.value;
                     setFieldValue('general.name', newValue);
                   }}
+                  onBlur={e => setFieldValue('general.name', e.target.value.trim())}
                   value={formValues.general?.name ?? existingDaoName}
                   disabled={readOnly}
                   placeholder={formValues.general?.name === undefined ? 'Amazing DAO' : ''}

--- a/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
+++ b/src/components/SafeSettings/TabContents/general/SafeGeneralSettingTab.tsx
@@ -114,11 +114,16 @@ export function SafeGeneralSettingTab() {
                 <InputComponent
                   isRequired={false}
                   onChange={e => {
-                    const newValue =
-                      e.target.value === existingDaoName ? undefined : e.target.value;
+                    const newInputValue = e.target.value;
+                    const newValue = newInputValue === existingDaoName ? undefined : newInputValue;
                     setFieldValue('general.name', newValue);
                   }}
-                  onBlur={e => setFieldValue('general.name', e.target.value.trim())}
+                  onBlur={e => {
+                    // Only trim the input value on blur
+                    const newInputValue = e.target.value.trim();
+                    const newValue = newInputValue === existingDaoName ? undefined : newInputValue;
+                    setFieldValue('general.name', newValue);
+                  }}
                   value={formValues.general?.name ?? existingDaoName}
                   disabled={readOnly}
                   placeholder={formValues.general?.name === undefined ? 'Amazing DAO' : ''}


### PR DESCRIPTION
### Summary

> Let's say I wanted to change my DAO name from "Decent" to "Decent DAO". You can't do that right now without doing some weird stuff, moving the cursor to between the "n" and the "t", for example, and adding the space there. Even worse, if you want to start from scratch, you delete "Decent" and start typing in the name, you still get stuck at the part where you need to enter a space.

To fix the issue described above.