### PR TITLE
`[ENG-1081]` WIP action first template creation flow

### DIFF
--- a/public/locales/en/actions.json
+++ b/public/locales/en/actions.json
@@ -6,5 +6,7 @@
   "comingSoon": "Coming Soon...",
   "comingSoonSub": "More actions on the way.",
   "transactionBuilderActionCard_single": "Transaction Builder: Execute {{ functionName }} at {{ targetAddress }}",
-  "transactionBuilderActionCard_multiple": "Transaction Builder: Batch {{ numOfTransactions }} transactions"
+  "transactionBuilderActionCard_multiple": "Transaction Builder: Batch {{ numOfTransactions }} transactions",
+  "createTemplateActionCard_single": "Create Template: Execute {{ functionName }} at {{ targetAddress }}",
+  "createTemplateActionCard_multiple": "Create Template: Batch {{ numOfTransactions }} transactions"
 }

--- a/src/components/ProposalBuilder/ProposalActionCard.tsx
+++ b/src/components/ProposalBuilder/ProposalActionCard.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Icon, IconButton, Text } from '@chakra-ui/react';
-import { ArrowsDownUp, CheckSquare, CraneTower, Trash } from '@phosphor-icons/react';
+import { ArrowsDownUp, CheckSquare, CraneTower, FilePlus, Trash } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { formatUnits, getAddress, isAddress } from 'viem';
 import PencilWithLineIcon from '../../assets/theme/custom/icons/PencilWithLineIcon';
@@ -183,6 +183,52 @@ function TransactionBuilderAction({
   );
 }
 
+function CreateTemplateAction({
+  action,
+  onRemove,
+}: {
+  action: CreateProposalAction;
+  onRemove: () => void;
+}) {
+  const { t } = useTranslation('actions');
+
+  return (
+    <Card my="0.5rem">
+      <Flex justifyContent="space-between">
+        <Flex
+          alignItems="center"
+          gap="0.5rem"
+        >
+          <Icon
+            as={FilePlus}
+            w="1.5rem"
+            h="1.5rem"
+            color="color-lilac-100"
+          />
+          <Text>
+            {action.transactions.length === 1
+              ? t('createTemplateActionCard_single', {
+                  functionName: action.transactions[0].functionName,
+                  targetAddress: createAccountSubstring(action.transactions[0].targetAddress),
+                })
+              : t('createTemplateActionCard_multiple', {
+                  numOfTransactions: action.transactions.length,
+                })}
+          </Text>
+        </Flex>
+        <Button
+          color="color-error-500"
+          variant="tertiary"
+          size="sm"
+          onClick={onRemove}
+        >
+          <Icon as={Trash} />
+        </Button>
+      </Flex>
+    </Card>
+  );
+}
+
 export function ProposalActionCard({
   action,
   removeAction,
@@ -219,6 +265,13 @@ export function ProposalActionCard({
   } else if (action.actionType === ProposalActionType.TRANSACTION_BUILDER) {
     return (
       <TransactionBuilderAction
+        action={action}
+        onRemove={() => removeAction(index)}
+      />
+    );
+  } else if (action.actionType === ProposalActionType.CREATE_TEMPLATE) {
+    return (
+      <CreateTemplateAction
         action={action}
         onRemove={() => removeAction(index)}
       />

--- a/src/components/ProposalBuilder/ProposalTransactionsForm.tsx
+++ b/src/components/ProposalBuilder/ProposalTransactionsForm.tsx
@@ -17,8 +17,9 @@ export interface ProposalTransactionsFormProps {
   setFieldValue: FormikProps<CreateProposalTransaction[]>['setFieldValue'];
   values: FormikProps<CreateProposalTransaction[]>['values'];
   errors?: FormikProps<CreateProposalTransaction[]>['errors'];
-  onSubmit?: (txs: CreateProposalTransaction[]) => void;
+  onSubmit?: (txs: CreateProposalTransaction[]) => Promise<void>;
   onClose?: () => void;
+  submitButtonText?: string;
 }
 
 export default function ProposalTransactionsForm(props: ProposalTransactionsFormProps) {
@@ -64,6 +65,7 @@ export function ProposalTransactionsFormModal({
   isProposalMode,
   onSubmit,
   onClose,
+  submitButtonText,
 }: ProposalTransactionsFormProps) {
   const [expandedIndecies, setExpandedIndecies] = useState<number[]>([0]);
   const { t } = useTranslation(['proposal']);
@@ -73,8 +75,8 @@ export function ProposalTransactionsFormModal({
       initialValues={[DEFAULT_PROPOSAL_TRANSACTION]}
       validateOnMount
       validationSchema={transactionValidationSchema}
-      onSubmit={values => {
-        onSubmit?.(values);
+      onSubmit={async values => {
+        await onSubmit?.(values);
         onClose?.();
       }}
     >
@@ -115,7 +117,7 @@ export function ProposalTransactionsFormModal({
               isDisabled={Object.values(errors).length > 0}
               type="submit"
             >
-              {t('labelAddTransactionsToProposal')}
+              {submitButtonText || t('labelAddTransactionsToProposal')}
             </Button>
           </form>
         );

--- a/src/components/ui/modals/AddActions.tsx
+++ b/src/components/ui/modals/AddActions.tsx
@@ -90,7 +90,7 @@ export function AddActions() {
   });
 
   const { open: openTransactionBuilderModal } = useDecentModal(ModalType.TRANSACTION_BUILDER, {
-    onSubmit: transactionBuilderData => {
+    onSubmit: async transactionBuilderData => {
       const actionType = ProposalActionType.TRANSACTION_BUILDER;
 
       addAction({

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -125,7 +125,10 @@ export type ModalPropsTypes = {
     onFallback: () => void;
   };
   [ModalType.TRANSACTION_BUILDER]: {
-    onSubmit?: (transactionBuilderData: FormikProps<CreateProposalTransaction[]>['values']) => void;
+    onSubmit?: (
+      transactionBuilderData: FormikProps<CreateProposalTransaction[]>['values'],
+    ) => Promise<void>;
+    submitButtonText?: string;
   };
   [ModalType.DAPPS_BROWSER]: {};
   [ModalType.DAPP_BROWSER]: {
@@ -403,6 +406,7 @@ const getModalData = (args: {
           isProposalMode={true}
           onSubmit={current.props.onSubmit}
           onClose={popModal}
+          submitButtonText={current.props.submitButtonText}
         />
       );
       modalSize = '2xl';

--- a/src/hooks/DAO/proposal/useCreateProposalTemplate.ts
+++ b/src/hooks/DAO/proposal/useCreateProposalTemplate.ts
@@ -6,8 +6,8 @@ import { normalize } from 'viem/ens';
 import { useDAOStore } from '../../../providers/App/AppProvider';
 import useIPFSClient from '../../../providers/App/hooks/useIPFSClient';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
-import { ProposalExecuteData } from '../../../types';
-import { CreateProposalForm } from '../../../types/proposalBuilder';
+import { BigIntValuePair, ProposalExecuteData } from '../../../types';
+import { CreateProposalForm, CreateProposalTransaction } from '../../../types/proposalBuilder';
 import { bigintSerializer } from '../../../utils/bigintSerializer';
 import { validateENSName } from '../../../utils/url';
 import { useNetworkEnsAddressAsync } from '../../useNetworkEnsAddress';
@@ -30,12 +30,6 @@ export default function useCreateProposalTemplate() {
   const prepareProposalTemplateProposal = useCallback(
     async (values: CreateProposalForm) => {
       if (proposalTemplates) {
-        const proposalMetadata = {
-          title: t('createProposalTemplateTitle'),
-          description: t('createProposalTemplateDescription'),
-          documentationUrl: '',
-        };
-
         const proposalTemplateData = {
           title: values.proposalMetadata.title.trim(),
           description: values.proposalMetadata.description.trim(),
@@ -69,17 +63,29 @@ export default function useCreateProposalTemplate() {
           args: [['proposalTemplates'], [Hash]],
         });
 
-        const proposal: ProposalExecuteData = {
-          metaData: proposalMetadata,
-          targets: [keyValuePairs],
-          values: [0n],
-          calldatas: [encodedUpdateValues],
-        };
-
-        return proposal;
+        return {
+          targetAddress: keyValuePairs,
+          functionName: 'updateValues',
+          calldata: encodedUpdateValues,
+          ethValue: {
+            bigintValue: 0n,
+            value: '0',
+          },
+          // parameters are passed for display purposes
+          parameters: [
+            {
+              signature: 'string[]',
+              valueArray: ['proposalTemplates'],
+            },
+            {
+              signature: 'string[]',
+              valueArray: [Hash],
+            },
+          ],
+        } as CreateProposalTransaction<BigIntValuePair>;
       }
     },
-    [client, getEnsAddress, keyValuePairs, proposalTemplates, t],
+    [client, getEnsAddress, keyValuePairs, proposalTemplates],
   );
 
   return { prepareProposalTemplateProposal };

--- a/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
+++ b/src/pages/dao/proposal-templates/SafeProposalTemplatesPage.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Flex, Grid, Show, Text } from '@chakra-ui/react';
 import { ArrowsDownUp, HourglassMedium, Parachute } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { AddPlus } from '../../../assets/theme/custom/icons/AddPlus';
 import ExampleTemplateCard from '../../../components/ProposalTemplates/ExampleTemplateCard';
@@ -34,6 +34,7 @@ export function SafeProposalTemplatesPage() {
   const { t: tProposalTemplate } = useTranslation('proposalTemplate');
   const { t: tCommon } = useTranslation('common');
   const { t: tBreadcrumbs } = useTranslation('breadcrumbs');
+  const { t: tProposalMetadata } = useTranslation('proposalMetadata');
 
   const { daoKey } = useCurrentDAOKey();
   const {
@@ -47,7 +48,7 @@ export function SafeProposalTemplatesPage() {
     contracts: { disperse },
   } = useNetworkConfigStore();
   const navigate = useNavigate();
-  const { addAction, resetActions } = useProposalActionsStore();
+  const { addAction, resetActions, setProposalMetadata } = useProposalActionsStore();
 
   const safeAddress = safe?.address;
   const { openSendAssetsModal } = useSendAssetsActionModal();
@@ -155,6 +156,31 @@ export function SafeProposalTemplatesPage() {
     addressPrefix,
   ]);
 
+  const { open: openTransactionBuilderModal } = useDecentModal(ModalType.TRANSACTION_BUILDER, {
+    onSubmit: async transactionBuilderData => {
+      if (!safeAddress) return;
+
+      const defaultProposalMetadata = {
+        title: tProposalMetadata('createProposalTemplateTitle'),
+        description: tProposalMetadata('createProposalTemplateDescription'),
+      };
+      const actionType = ProposalActionType.CREATE_TEMPLATE;
+
+      resetActions();
+      // TODO mention template in action description?
+      addAction({
+        actionType: actionType,
+        content: <></>,
+        transactions: transactionBuilderData,
+      });
+      setProposalMetadata('title', defaultProposalMetadata.title);
+      setProposalMetadata('description', defaultProposalMetadata.description);
+
+      navigate(DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, safeAddress));
+    },
+    submitButtonText: tModals('submitProposal'),
+  });
+
   return (
     <div>
       <PageHeader
@@ -167,15 +193,14 @@ export function SafeProposalTemplatesPage() {
         ]}
       >
         {canUserCreateProposal && safeAddress && (
-          <Link
-            to={DAO_ROUTES.proposalTemplateNew.relative(addressPrefix, safeAddress)}
+          <Button
+            onClick={openTransactionBuilderModal}
             data-testid="proposalTemplates-create"
+            minW={0}
           >
-            <Button minW={0}>
-              <AddPlus />
-              <Show above="sm">{tCommon('create')}</Show>
-            </Button>
-          </Link>
+            <AddPlus />
+            <Show above="sm">{tCommon('create')}</Show>
+          </Button>
         )}
       </PageHeader>
       <Flex

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -41,6 +41,7 @@ export function SafeCreateProposalTemplatePage() {
   const [initialProposalTemplate, setInitialProposalTemplate] = useState(DEFAULT_PROPOSAL);
   const { prepareProposalTemplateProposal } = useCreateProposalTemplate();
   const [searchParams] = useSearchParams();
+  // TODO fork template?
   const defaultProposalTemplatesHash = useMemo(
     () => searchParams?.get('templatesHash'),
     [searchParams],

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -11,13 +11,19 @@ import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/cons
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../../constants/common';
 import { DAO_ROUTES } from '../../../../../constants/routes';
+import useCreateProposalTemplate from '../../../../../hooks/DAO/proposal/useCreateProposalTemplate';
 import { usePrepareProposal } from '../../../../../hooks/DAO/proposal/usePrepareProposal';
 import { useCurrentDAOKey } from '../../../../../hooks/DAO/useCurrentDAOKey';
 import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useDAOStore } from '../../../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useProposalActionsStore } from '../../../../../store/actions/useProposalActionsStore';
-import { CreateProposalSteps, CreateProposalTransaction } from '../../../../../types';
+import {
+  CreateProposalForm,
+  CreateProposalSteps,
+  CreateProposalTransaction,
+  ProposalActionType,
+} from '../../../../../types';
 
 export function SafeProposalWithActionsCreatePage() {
   useEffect(() => {
@@ -30,7 +36,31 @@ export function SafeProposalWithActionsCreatePage() {
   } = useDAOStore({ daoKey });
 
   const { prepareProposal } = usePrepareProposal();
+  const { prepareProposalTemplateProposal } = useCreateProposalTemplate();
   const { getTransactions, actions, proposalMetadata } = useProposalActionsStore();
+
+  const prepareProposalData = async (values: CreateProposalForm) => {
+    let createTemplateTransactions = actions
+      .filter(a => a.actionType === ProposalActionType.CREATE_TEMPLATE)
+      .flatMap(a => a.transactions);
+    const otherTransactions = actions
+      .filter(a => a.actionType !== ProposalActionType.CREATE_TEMPLATE)
+      .flatMap(a => a.transactions);
+
+    if (createTemplateTransactions.length > 0) {
+      const txn = await prepareProposalTemplateProposal({
+        proposalMetadata: values.proposalMetadata,
+        transactions: createTemplateTransactions,
+      });
+      if (txn) {
+        createTemplateTransactions = [txn];
+      }
+    }
+    return prepareProposal({
+      ...values,
+      transactions: otherTransactions.concat(createTemplateTransactions),
+    });
+  };
 
   const [transactions, setTransactions] = useState<CreateProposalTransaction[]>([]);
   useEffect(() => {
@@ -79,6 +109,17 @@ export function SafeProposalWithActionsCreatePage() {
     [defaultProposalValues, transactions],
   );
 
+  // Load potential forked template params
+  // const [searchParams] = useSearchParams();
+  // const defaultProposalTemplatesHash = useMemo(
+  //   () => searchParams?.get('templatesHash'),
+  //   [searchParams],
+  // );
+  // const defaultProposalTemplateIndex = useMemo(
+  //   () => searchParams?.get('templateIndex'),
+  //   [searchParams],
+  // );
+
   if (!type || !safe?.address || !safe) {
     return (
       <Center minH={`calc(100vh - ${HEADER_HEIGHT})`}>
@@ -120,7 +161,7 @@ export function SafeProposalWithActionsCreatePage() {
       templateDetails={null}
       streamsDetails={null}
       proposalMetadataTypeProps={DEFAULT_PROPOSAL_METADATA_TYPE_PROPS(t)}
-      prepareProposalData={prepareProposal}
+      prepareProposalData={prepareProposalData}
       mainContent={() => null}
       showActionsExperience
     />

--- a/src/types/proposalBuilder.ts
+++ b/src/types/proposalBuilder.ts
@@ -70,6 +70,7 @@ export enum ProposalActionType {
   DAPP_INTEGRATION = 'dapp_integration',
   TRANSACTION_BUILDER = 'transaction_builder',
   UPDATE_REVENUE_SHARE_SPLITS = 'update_revenue_share_splits',
+  CREATE_TEMPLATE = 'create_template',
 }
 
 export type CreateProposalActionData<T = BigIntValuePair> = {


### PR DESCRIPTION
### Summary

- [X] Added new action type "Create Template"
- [X] Use generic `SafeProposalWithActionsCreatePage` to handle template creation
- [ ] maybe also handle template fork and then remove `SafeCreateProposalTemplatePage`

### Screenshots

#### Attach transactions through modal first

<img width="631" height="956" alt="image" src="https://github.com/user-attachments/assets/abff4b54-bf77-4a6e-ada0-ec3bd0b7787f" />

#### Then input proposal metadata

<img width="1119" height="920" alt="image" src="https://github.com/user-attachments/assets/54bb31fd-151f-4bf9-a194-1cda57519946" />
<img width="1114" height="902" alt="image" src="https://github.com/user-attachments/assets/138bb30f-199a-48a5-aa70-bd71751d7882" />
