### PR TITLE
`[ENG-1141]` Prevent blocker.reset from overriding user navigation after proceed

### DIFF
--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -99,9 +99,6 @@ export function ProposalBuilder({
     onDiscardChanges: () => {
       resetActions();
       pushNavigation.current = false;
-
-      // Small delay to ensure that the proposal is created and actions are reset
-      setTimeout(() => navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress!)), 0);
     },
   });
   const successCallback = () => {

--- a/src/hooks/useUnsavedChangesBlocker.ts
+++ b/src/hooks/useUnsavedChangesBlocker.ts
@@ -16,11 +16,10 @@ export function useUnsavedChangesBlocker({
 
   const { open: openModal } = useDecentModal(ModalType.WARN_UNSAVED_CHANGES, {
     discardChanges: () => {
+      onDiscardChanges();
       if (blocker.state === 'blocked' && blocker.proceed) {
         blocker.proceed();
-        blocker.reset();
       }
-      onDiscardChanges();
     },
     keepEditing: () => {
       if (blocker.state === 'blocked' && blocker.reset) {


### PR DESCRIPTION
### Summary
The original implementation called `blocker.reset()` immediately after `proceed()`, leaving navigation to be handled in a callback that always redirected to the home page. This caused user navigation to be overridden if they intended to go to a different page.
This fix removes the unnecessary `reset()` call, allowing `proceed()` to navigate to the intended route as requested by the user.

### Changes

* Removed the `blocker.reset()` invocation following `proceed()`.
* Navigation now respects the user’s intended destination instead of defaulting to home.

### Testing Steps

1. Navigate to any DAO.
2. Go to “Create Proposal” from scratch.
3. Add some text to the title.
4. Click “DAO Favorites” and select any DAO.
5. Verify that the app navigates to the selected DAO page rather than the home page.