### PR TITLE
`[ENG-1489]` Implement Claim Fund Banners

### DIFF
--- a/src/assets/theme/components/alert/alert.variants.ts
+++ b/src/assets/theme/components/alert/alert.variants.ts
@@ -18,8 +18,68 @@ const info = definePartsStyle({
   spinner: {},
 });
 
+const fundraisingBanner = definePartsStyle({
+  title: {
+    textStyle: 'text-sm-medium',
+    color: 'color-base-information-foreground',
+    h: 'fit-content',
+  },
+  container: {
+    bg: '#0e1d28',
+    border: '1px solid',
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderRadius: '12px',
+    p: '12px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  description: {
+    h: 'fit-content',
+    textStyle: 'text-sm-regular',
+    color: 'color-base-information-foreground',
+  },
+  icon: {
+    color: 'color-base-information-foreground',
+    '& > svg': {
+      boxSize: '24px',
+    },
+  },
+  spinner: {},
+});
+
+const successBanner = definePartsStyle({
+  title: {
+    textStyle: 'text-sm-medium',
+    color: 'color-base-success',
+    h: 'fit-content',
+  },
+  container: {
+    bg: '#0c2517',
+    border: '1px solid',
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderRadius: '12px',
+    p: '12px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  description: {
+    textStyle: 'text-sm-regular',
+    color: 'color-base-success',
+    h: 'fit-content',
+  },
+  icon: {
+    color: 'color-base-success',
+    '& > svg': {
+      boxSize: '24px',
+    },
+  },
+  spinner: {},
+});
+
 const alertVariants = {
   info,
+  fundraisingBanner,
+  successBanner,
 };
 
 export default alertVariants;

--- a/src/assets/theme/components/alert/alert.variants.ts
+++ b/src/assets/theme/components/alert/alert.variants.ts
@@ -25,9 +25,9 @@ const fundraisingBanner = definePartsStyle({
     h: 'fit-content',
   },
   container: {
-    bg: '#0e1d28',
+    bg: 'color-information-950',
     border: '1px solid',
-    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: 'color-layout-border',
     borderRadius: '12px',
     p: '12px',
     display: 'flex',
@@ -54,9 +54,9 @@ const successBanner = definePartsStyle({
     h: 'fit-content',
   },
   container: {
-    bg: '#0c2517',
+    bg: 'color-success-950',
     border: '1px solid',
-    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: 'color-layout-border',
     borderRadius: '12px',
     p: '12px',
     display: 'flex',

--- a/src/components/TokenSales/TokenSaleBanner.tsx
+++ b/src/components/TokenSales/TokenSaleBanner.tsx
@@ -7,6 +7,7 @@ interface TokenSaleBannerProps {
   buttonText?: string;
   onButtonClick?: () => void;
   variant?: 'fundraisingBanner' | 'successBanner';
+  buttonDisabled?: boolean;
 }
 
 export function TokenSaleBanner({
@@ -15,6 +16,7 @@ export function TokenSaleBanner({
   buttonText,
   onButtonClick,
   variant = 'fundraisingBanner',
+  buttonDisabled = false,
 }: TokenSaleBannerProps) {
   const iconComponent = variant === 'successBanner' ? CheckCircle : Info;
   const color =
@@ -45,6 +47,7 @@ export function TokenSaleBanner({
           h="32px"
           borderRadius="8px"
           onClick={onButtonClick}
+          isDisabled={buttonDisabled}
           _hover={{
             bg: 'rgba(255, 255, 255, 0.1)',
           }}

--- a/src/components/TokenSales/TokenSaleBanner.tsx
+++ b/src/components/TokenSales/TokenSaleBanner.tsx
@@ -1,0 +1,57 @@
+import { Alert, AlertTitle, AlertDescription, Button, Flex, Icon } from '@chakra-ui/react';
+import { Info, CheckCircle } from '@phosphor-icons/react';
+
+interface TokenSaleBannerProps {
+  title: string;
+  description: string;
+  buttonText?: string;
+  onButtonClick?: () => void;
+  variant?: 'fundraisingBanner' | 'successBanner';
+}
+
+export function TokenSaleBanner({
+  title,
+  description,
+  buttonText,
+  onButtonClick,
+  variant = 'fundraisingBanner',
+}: TokenSaleBannerProps) {
+  const iconComponent = variant === 'successBanner' ? CheckCircle : Info;
+  const color =
+    variant === 'successBanner' ? 'color-base-success' : 'color-base-information-foreground';
+  return (
+    <Alert variant={variant}>
+      <Icon
+        as={iconComponent}
+        color={color}
+        boxSize="24px"
+      />
+      <Flex
+        direction="column"
+        flex="1"
+        gap="0"
+      >
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>{description}</AlertDescription>
+      </Flex>
+      {buttonText && onButtonClick && (
+        <Button
+          size="xs"
+          variant="ghost"
+          color="color-charcoal-50"
+          textStyle="text-xs-medium"
+          px="12px"
+          py="0"
+          h="32px"
+          borderRadius="8px"
+          onClick={onButtonClick}
+          _hover={{
+            bg: 'rgba(255, 255, 255, 0.1)',
+          }}
+        >
+          {buttonText}
+        </Button>
+      )}
+    </Alert>
+  );
+}

--- a/src/components/TokenSales/TokenSalesTable.tsx
+++ b/src/components/TokenSales/TokenSalesTable.tsx
@@ -15,6 +15,7 @@ import { CaretUpDown, DotsThree } from '@phosphor-icons/react';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DAO_ROUTES } from '../../constants/routes';
+import { useTokenSaleClaimFunds } from '../../hooks/DAO/proposal/useTokenSaleClaimFunds';
 import { useCurrentDAOKey } from '../../hooks/DAO/useCurrentDAOKey';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { TokenSaleData } from '../../types/tokenSale';
@@ -35,6 +36,7 @@ export function TokenSalesTable({ tokenSales }: TokenSalesTableProps) {
   const navigate = useNavigate();
   const { safeAddress } = useCurrentDAOKey();
   const { addressPrefix } = useNetworkConfigStore();
+  const { claimFunds, pending } = useTokenSaleClaimFunds();
 
   const sortedSales = useMemo(() => {
     // Sort by active status first, then by end date
@@ -81,8 +83,7 @@ export function TokenSalesTable({ tokenSales }: TokenSalesTableProps) {
           {
             optionKey: 'claimFunds',
             onClick: () => {
-              // TODO: Navigate to claim funds
-              console.log('Claim funds for:', sale.name);
+              claimFunds(sale.address, sale.name);
             },
           },
         ]
@@ -208,6 +209,7 @@ export function TokenSalesTable({ tokenSales }: TokenSalesTableProps) {
                       p: '4px',
                       border: '1px solid',
                       borderColor: 'color-layout-border-10',
+                      isDisabled: pending,
                       _hover: {
                         bg: 'color-content-content2',
                       },

--- a/src/hooks/DAO/proposal/useTokenSaleClaimFunds.ts
+++ b/src/hooks/DAO/proposal/useTokenSaleClaimFunds.ts
@@ -1,0 +1,34 @@
+import { abis } from '@decentdao/decent-contracts';
+import { useCallback } from 'react';
+import { Address, getContract } from 'viem';
+import { useNetworkWalletClient } from '../../useNetworkWalletClient';
+import { useTransaction } from '../../utils/useTransaction';
+
+export const useTokenSaleClaimFunds = () => {
+  const { data: walletClient } = useNetworkWalletClient();
+  const [contractCall, pending] = useTransaction();
+
+  const claimFunds = useCallback(
+    (tokenSaleAddress: Address, tokenSaleName: string) => {
+      if (!walletClient) {
+        throw new Error('Wallet client is not available');
+      }
+
+      const tokenSaleContract = getContract({
+        address: tokenSaleAddress,
+        abi: abis.deployables.TokenSaleV1,
+        client: walletClient,
+      });
+
+      contractCall({
+        contractFn: () => tokenSaleContract.write.sellerSettle(),
+        pendingMessage: `Claiming funds from ${tokenSaleName}...`,
+        successMessage: `Successfully claimed funds from ${tokenSaleName}`,
+        failedMessage: `Failed to claim funds from ${tokenSaleName}`,
+      });
+    },
+    [walletClient, contractCall],
+  );
+
+  return { claimFunds, pending };
+};

--- a/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
+++ b/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
@@ -9,6 +9,7 @@ import { TokenSaleInfoCard } from '../../../components/TokenSales/TokenSaleInfoC
 import { TokenSaleProgressCard } from '../../../components/TokenSales/TokenSaleProgressCard';
 import PageHeader from '../../../components/ui/page/Header/PageHeader';
 import { CONTENT_MAXW } from '../../../constants/common';
+import { useTokenSaleClaimFunds } from '../../../hooks/DAO/proposal/useTokenSaleClaimFunds';
 import { useCurrentDAOKey } from '../../../hooks/DAO/useCurrentDAOKey';
 import { useDAOStore } from '../../../providers/App/AppProvider';
 
@@ -16,6 +17,7 @@ export function SafeTokenSaleDetailsPage() {
   const { saleId } = useParams<{ saleId: string }>();
   const { daoKey } = useCurrentDAOKey();
   const { tokenSales } = useDAOStore({ daoKey });
+  const { claimFunds, pending } = useTokenSaleClaimFunds();
 
   const tokenSale = useMemo(() => {
     if (!saleId || !tokenSales) return null;
@@ -112,32 +114,34 @@ export function SafeTokenSaleDetailsPage() {
           />
 
           {/* Fundraising Goal Not Met Banner */}
-          {tokenSale.totalCommitments < tokenSale.maximumTotalCommitment / 2n && (
-            <TokenSaleBanner
-              title="You did not meet your minimum fundraising goal."
-              description={`You only raised ${formatCurrency(tokenSale.totalCommitments)}. Reclaim your sale tokens to return funds.`}
-              buttonText="Reclaim Tokens"
-              onButtonClick={() => {
-                // TODO: Implement reclaim tokens functionality
-                console.log('Reclaim tokens clicked');
-              }}
-              variant="fundraisingBanner"
-            />
-          )}
+          {!tokenSale.isActive &&
+            tokenSale.totalCommitments < tokenSale.maximumTotalCommitment / 2n && (
+              <TokenSaleBanner
+                title="You did not meet your minimum fundraising goal."
+                description={`You only raised ${formatCurrency(tokenSale.totalCommitments)}. Reclaim your sale tokens to return funds.`}
+                buttonText="Reclaim Tokens"
+                onButtonClick={() => {
+                  claimFunds(tokenSale.address, tokenSale.name);
+                }}
+                variant="fundraisingBanner"
+                buttonDisabled={pending}
+              />
+            )}
 
           {/* Successful Sale Banner */}
-          {tokenSale.totalCommitments >= tokenSale.maximumTotalCommitment / 2n && (
-            <TokenSaleBanner
-              title="Congratulations, your sale was successful!"
-              description={`You raised ${formatCurrency(tokenSale.totalCommitments)}. Your funds are ready to be claimed.`}
-              buttonText="Claim Funds"
-              onButtonClick={() => {
-                // TODO: Implement claim funds functionality
-                console.log('Claim funds clicked');
-              }}
-              variant="successBanner"
-            />
-          )}
+          {!tokenSale.isActive &&
+            tokenSale.totalCommitments >= tokenSale.maximumTotalCommitment / 2n && (
+              <TokenSaleBanner
+                title="Congratulations, your sale was successful!"
+                description={`You raised ${formatCurrency(tokenSale.totalCommitments)}. Your funds are ready to be claimed.`}
+                buttonText="Claim Funds"
+                onButtonClick={() => {
+                  claimFunds(tokenSale.address, tokenSale.name);
+                }}
+                variant="successBanner"
+                buttonDisabled={pending}
+              />
+            )}
         </VStack>
 
         {/* Sale Configuration */}

--- a/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
+++ b/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
@@ -126,7 +126,7 @@ export function SafeTokenSaleDetailsPage() {
           )}
 
           {/* Successful Sale Banner */}
-          {tokenSale.totalCommitments <= tokenSale.maximumTotalCommitment / 2n && (
+          {tokenSale.totalCommitments >= tokenSale.maximumTotalCommitment / 2n && (
             <TokenSaleBanner
               title="Congratulations, your sale was successful!"
               description={`You raised ${formatCurrency(tokenSale.totalCommitments)}. Your funds are ready to be claimed.`}

--- a/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
+++ b/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
@@ -114,7 +114,7 @@ export function SafeTokenSaleDetailsPage() {
           />
 
           {/* Fundraising Goal Not Met Banner */}
-          {tokenSale.saleState > 3 &&
+          {tokenSale.saleState === 3 &&
             tokenSale.totalCommitments < tokenSale.maximumTotalCommitment / 2n && (
               <TokenSaleBanner
                 title="You did not meet your minimum fundraising goal."

--- a/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
+++ b/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
@@ -114,7 +114,7 @@ export function SafeTokenSaleDetailsPage() {
           />
 
           {/* Fundraising Goal Not Met Banner */}
-          {!tokenSale.isActive &&
+          {tokenSale.saleState > 3 &&
             tokenSale.totalCommitments < tokenSale.maximumTotalCommitment / 2n && (
               <TokenSaleBanner
                 title="You did not meet your minimum fundraising goal."
@@ -129,7 +129,7 @@ export function SafeTokenSaleDetailsPage() {
             )}
 
           {/* Successful Sale Banner */}
-          {!tokenSale.isActive &&
+          {tokenSale.saleState === 2 &&
             tokenSale.totalCommitments >= tokenSale.maximumTotalCommitment / 2n && (
               <TokenSaleBanner
                 title="Congratulations, your sale was successful!"

--- a/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
+++ b/src/pages/dao/token-sale/SafeTokenSaleDetailsPage.tsx
@@ -3,6 +3,7 @@ import { CheckCircle } from '@phosphor-icons/react';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { formatUnits } from 'viem';
+import { TokenSaleBanner } from '../../../components/TokenSales/TokenSaleBanner';
 import { TokenSaleCountdown } from '../../../components/TokenSales/TokenSaleCountdown';
 import { TokenSaleInfoCard } from '../../../components/TokenSales/TokenSaleInfoCard';
 import { TokenSaleProgressCard } from '../../../components/TokenSales/TokenSaleProgressCard';
@@ -109,6 +110,34 @@ export function SafeTokenSaleDetailsPage() {
             minimum={tokenSale.maximumTotalCommitment / 2n} // Assuming minimum is half of max
             commitmentTokenDecimals={6} // Assuming USDC
           />
+
+          {/* Fundraising Goal Not Met Banner */}
+          {tokenSale.totalCommitments < tokenSale.maximumTotalCommitment / 2n && (
+            <TokenSaleBanner
+              title="You did not meet your minimum fundraising goal."
+              description={`You only raised ${formatCurrency(tokenSale.totalCommitments)}. Reclaim your sale tokens to return funds.`}
+              buttonText="Reclaim Tokens"
+              onButtonClick={() => {
+                // TODO: Implement reclaim tokens functionality
+                console.log('Reclaim tokens clicked');
+              }}
+              variant="fundraisingBanner"
+            />
+          )}
+
+          {/* Successful Sale Banner */}
+          {tokenSale.totalCommitments <= tokenSale.maximumTotalCommitment / 2n && (
+            <TokenSaleBanner
+              title="Congratulations, your sale was successful!"
+              description={`You raised ${formatCurrency(tokenSale.totalCommitments)}. Your funds are ready to be claimed.`}
+              buttonText="Claim Funds"
+              onButtonClick={() => {
+                // TODO: Implement claim funds functionality
+                console.log('Claim funds clicked');
+              }}
+              variant="successBanner"
+            />
+          )}
         </VStack>
 
         {/* Sale Configuration */}

--- a/src/types/tokenSale.ts
+++ b/src/types/tokenSale.ts
@@ -15,6 +15,7 @@ export interface TokenSaleData {
   saleEndTimestamp: bigint;
   minimumCommitment: bigint;
   maximumCommitment: bigint;
+  // TODO create enum
   saleState: number; // 0: NOT_STARTED, 1: ACTIVE, 2: SUCCEEDED, 3: FAILED
   saleProceedsReceiver: Address;
   // Computed fields for compatibility


### PR DESCRIPTION
Note: Left a TODO to update `saleState` into a ENUM to match the contract enum. I'll do that in a future PR so I don't have to make changes down the stack

## Screenshots
(Not shown at same time in real world)

<img width="1280" height="900" alt="localhost_3000_token-sale_0xA96C8E16fa5eef5A093a506a03ccA0D7eBd310D4_dao=sep_0xb1d01DB36bdbc27c131483Cf4262122547b5bf97(Desktop)" src="https://github.com/user-attachments/assets/ee5c909f-5f85-42d4-bad4-e9da08703ae4" />
