### PR TITLE
[`ENG-1496`] Update 'Sponsored Voting' to 'Gasless Voting'

### DIFF
--- a/public/locales/en/gaslessVoting.json
+++ b/public/locales/en/gaslessVoting.json
@@ -1,8 +1,8 @@
 {
-  "gaslessVotingLabel": "Sponsored Voting",
+  "gaslessVotingLabel": "Gasless Voting",
   "gaslessVotingDescription": "Create a paymaster to sponsor network fees for proposal votes. The paymaster will be created after your DAO is deployed.",
   "gaslessVotingGettingStarted": "To get you started, we're covering your first 0.1 {{symbol}} of gas fees. You can top up your balance in your DAO settings.",
-  "gaslessVotingLabelSettings": "Sponsored Votes",
+  "gaslessVotingLabelSettings": "Gasless Voting",
   "gaslessVotingDescriptionSettings": "Create a paymaster to sponsor network fees for proposal votes.",
   "gaslessStakingRequirement": "A staking of {{amount}} {{symbol}} is required to enable gasless voting. It can be unstaked after 1 day if gasless voting is disabled.",
   "addGas": "Refill",


### PR DESCRIPTION
Turns out that we used the term 'gasless voting' more commonly than 'sponsored voting' already, so this change is very small. None of the other instances of the term 'sponsor' or 'sponsored' needed to be changed.

I also made an executive decision to change the label in the settings modal from 'Gasless Votes' to 'Gasless Voting', which to me just feels better.